### PR TITLE
[fix]: 适配user模块接口和JWT鉴权中间件后，启动FastAPI无法正常工作

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 
 from fastapi import FastAPI
-from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.api.routes.tasks import router as tasks_router
 from app.api.routes.papers import router as papers_router
@@ -11,8 +10,8 @@ from middleware.jwt_middleware import JWTAuthMiddleware
 
 app = FastAPI(title=settings.APP_NAME)
 
-# ── JWT authentication middleware ──
-app.add_middleware(BaseHTTPMiddleware, cls=JWTAuthMiddleware)
+# ── JWT authentication middleware (ASGI middleware, not BaseHTTPMiddleware) ──
+app.add_middleware(JWTAuthMiddleware)
 
 
 @app.on_event("startup")

--- a/src/backend/module/user/controller/auth_router.py
+++ b/src/backend/module/user/controller/auth_router.py
@@ -3,12 +3,12 @@ from fastapi.security import OAuth2PasswordRequestForm
 from pydantic import BaseModel, EmailStr
 
 
-from src.backend.module.user.service.auth_service import (
+from module.user.service.auth_service import (
     register_user,
     authenticate_user,
 )
-from src.backend.utils.response import success, error
-from src.backend.utils.redis_client import get_redis
+from utils.response import success, error
+from utils.redis_client import get_redis
 import random
 import os
 import smtplib
@@ -138,7 +138,7 @@ async def change_password(payload: ChangePasswordIn):
         await r.delete(key)
 
         # perform password change via service
-        from src.backend.module.user.service.auth_service import change_user_password
+        from module.user.service.auth_service import change_user_password
 
         updated = await change_user_password(payload.email, payload.new_password)
         if not updated:

--- a/src/backend/module/user/controller/user_router.py
+++ b/src/backend/module/user/controller/user_router.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel
 
-from src.backend.module.user.service.auth_service import (
+from module.user.service.auth_service import (
     get_user_by_id,
     update_user_name,
 )
-from src.backend.utils.response import success, error
+from utils.response import success, error
 
 
 router = APIRouter()

--- a/src/backend/module/user/service/auth_service.py
+++ b/src/backend/module/user/service/auth_service.py
@@ -7,8 +7,8 @@ import jwt
 from passlib.context import CryptContext
 from sqlalchemy import select
 
-from src.backend.db.session import get_session
-from src.backend.db.models import User
+from db.session import get_session
+from db.models import User
 
 
 pwd_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")


### PR DESCRIPTION
一共修复了 **4 个文件**：

| 文件 | 问题 | 修复 |
|------|------|------|
| `module/user/service/auth_service.py` | `from src.backend.db...` | → `from db...` |
| `module/user/controller/auth_router.py` | 两处 `from src.backend.module...`、`from src.backend.utils...` | → `from module...`、`from utils...` |
| `module/user/controller/user_router.py` | `from src.backend.module...`、`from src.backend.utils...` | → `from module...`、`from utils...` |
| `app/main.py` | `app.add_middleware(BaseHTTPMiddleware, cls=JWTAuthMiddleware)` | → `app.add_middleware(JWTAuthMiddleware)` |

**根本原因**：backend 目录不是 Python 包，`from src.backend.xxx` 这种导入永远无法工作。改用直接包名（`db`、`module`、`utils`）即可。

已进行更改。

Issue #27