### PR TITLE
Feature/celery vectorization

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -3,7 +3,7 @@ APP_NAME=Scider Backend
 API_PREFIX=/api
 
 # ── Database ──────────────────────────────────────────────────────────────────
-# MySQL (asyncmy 驱动)，也可换为 PostgreSQL (asyncpg 驱动)
+# MySQL（asyncmy）
 DATABASE_URL=mysql+asyncmy://root:218218wcj@localhost:3306/db?charset=utf8mb4
 
 # 连接池配置（可选）
@@ -33,6 +33,14 @@ QWEN_MODEL=qwen-plus
 LLM_TIMEOUT=120
 LLM_MAX_TOKENS=1024
 LLM_TEMPERATURE=0.2
+
+# ── Embeddings（写入 paper_embedding 表 JSON）───────────────────────────────────
+# OpenAI 兼容接口；留空 EMBEDDING_BASE_URL 时沿用当前 LLM 提供商的 BASE_URL
+EMBEDDING_API_KEY=
+EMBEDDING_BASE_URL=
+EMBEDDING_MODEL=text-embedding-3-small
+EMBEDDING_DIM=1536
+EMBEDDING_TIMEOUT=120
 
 # ── PDF Upload ────────────────────────────────────────────────────────────────
 UPLOAD_DIR=uploads/papers

--- a/src/backend/app/core/config.py
+++ b/src/backend/app/core/config.py
@@ -39,6 +39,15 @@ class Settings:
     LLM_TEMPERATURE = float(os.getenv("LLM_TEMPERATURE", "0.2"))
 
     # ──────────────────────────────────────────────
+    # Embeddings (OpenAI-compatible API) → MySQL paper_embedding.embedding (JSON)
+    # ──────────────────────────────────────────────
+    EMBEDDING_API_KEY = os.getenv("EMBEDDING_API_KEY", "")
+    EMBEDDING_BASE_URL = os.getenv("EMBEDDING_BASE_URL", "")
+    EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
+    EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "1536"))
+    EMBEDDING_TIMEOUT = int(os.getenv("EMBEDDING_TIMEOUT", "120"))
+
+    # ──────────────────────────────────────────────
     # PDF upload settings
     # ──────────────────────────────────────────────
     UPLOAD_DIR = os.getenv("UPLOAD_DIR", "uploads/papers")

--- a/src/backend/app/core/embedding_client.py
+++ b/src/backend/app/core/embedding_client.py
@@ -1,0 +1,52 @@
+"""OpenAI-compatible embeddings API (vectors persisted as JSON in MySQL)."""
+
+import os
+
+from openai import OpenAI
+
+from app.core.config import settings
+
+
+def _embedding_client() -> OpenAI:
+    api_key = (
+        settings.EMBEDDING_API_KEY
+        or settings.DEEPSEEK_API_KEY
+        or settings.QWEN_API_KEY
+    )
+    if not api_key:
+        raise RuntimeError(
+            "No embedding API key: set EMBEDDING_API_KEY or LLM provider keys (DEEPSEEK_API_KEY / QWEN_API_KEY)."
+        )
+    base_url = settings.EMBEDDING_BASE_URL
+    if not base_url:
+        provider = settings.LLM_PROVIDER.lower()
+        base_url = (
+            settings.QWEN_BASE_URL if provider == "qwen" else settings.DEEPSEEK_BASE_URL
+        )
+    return OpenAI(api_key=api_key, base_url=base_url, timeout=settings.EMBEDDING_TIMEOUT)
+
+
+def create_embedding(text: str) -> list[float]:
+    """
+    Embed a single text chunk. Returns a vector of length settings.EMBEDDING_DIM
+    (truncated if the model returns a larger dimension).
+    """
+    raw = (text or "").strip()
+    if not raw:
+        raise ValueError("Embedding input text is empty")
+
+    max_chars = int(os.getenv("EMBEDDING_MAX_CHARS", "24000"))
+    if len(raw) > max_chars:
+        raw = raw[:max_chars]
+
+    client = _embedding_client()
+    response = client.embeddings.create(model=settings.EMBEDDING_MODEL, input=raw)
+    vec = list(response.data[0].embedding)
+    dim = settings.EMBEDDING_DIM
+    if len(vec) > dim:
+        vec = vec[:dim]
+    elif len(vec) < dim:
+        raise RuntimeError(
+            f"Embedding length {len(vec)} < EMBEDDING_DIM {dim}; change EMBEDDING_DIM or model."
+        )
+    return vec

--- a/src/backend/app/tasks/__init__.py
+++ b/src/backend/app/tasks/__init__.py
@@ -1,4 +1,4 @@
 # app/tasks/__init__.py
-from app.tasks import example_tasks, llm_tasks, parse_task
+from app.tasks import embedding_tasks, example_tasks, llm_tasks, parse_task
 
-__all__ = ["example_tasks", "llm_tasks", "parse_task"]
+__all__ = ["embedding_tasks", "example_tasks", "llm_tasks", "parse_task"]

--- a/src/backend/app/tasks/embedding_tasks.py
+++ b/src/backend/app/tasks/embedding_tasks.py
@@ -1,0 +1,116 @@
+"""
+Celery task: compute embedding via OpenAI-compatible API and upsert into MySQL (paper_embedding.embedding JSON).
+"""
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import select
+
+from app.celery_app import celery_app
+from app.core.config import settings
+from app.core.embedding_client import create_embedding
+
+logger = logging.getLogger(__name__)
+
+
+def _ensure_backend_root_in_path() -> None:
+    backend_root = Path(__file__).resolve().parents[2]
+    s = str(backend_root)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+
+async def _fetch_paper_embed_text(paper_id: str) -> str:
+    """Load title/abstract/keypoints from Paper/KeyPoints for embedding."""
+    _ensure_backend_root_in_path()
+    from db.models import KeyPoints, Paper
+    from db.session import get_session
+
+    async with get_session() as session:
+        result = await session.execute(select(Paper).where(Paper.id == paper_id))
+        paper = result.scalar_one_or_none()
+        if paper is None:
+            return ""
+
+        parts = [paper.title or "", paper.abstract or ""]
+        kp_result = await session.execute(select(KeyPoints).where(KeyPoints.paper_id == paper_id))
+        kp = kp_result.scalar_one_or_none()
+        if kp:
+            parts.extend(
+                [
+                    kp.background or "",
+                    kp.methodology or "",
+                    kp.innovation or "",
+                    kp.conclusion or "",
+                ]
+            )
+        return "\n".join(p for p in parts if p).strip()
+
+
+async def _upsert_paper_embedding(paper_id: str, embedding: list[float]) -> None:
+    from db.models import PaperEmbedding
+    from db.session import get_session
+
+    payload = [float(x) for x in embedding]
+
+    async with get_session() as session:
+        async with session.begin():
+            row = await session.get(PaperEmbedding, paper_id)
+            if row is None:
+                session.add(
+                    PaperEmbedding(
+                        paper_id=paper_id,
+                        embedding=payload,
+                        model_name=settings.EMBEDDING_MODEL,
+                    )
+                )
+            else:
+                row.embedding = payload
+                row.model_name = settings.EMBEDDING_MODEL
+
+
+@celery_app.task(
+    name="app.tasks.embed_paper",
+    bind=True,
+    max_retries=3,
+    default_retry_delay=20,
+)
+def embed_paper_task(self, paper_id: str, embed_text: Optional[str] = None) -> dict:
+    """
+    Compute embedding for ``embed_text`` or load text from Paper/KeyPoints.
+
+    Returns:
+        ``paper_id``, ``model``, ``dim``.
+    """
+    logger.info("[Embed] start paper_id=%s", paper_id)
+
+    text = (embed_text or "").strip()
+    if not text:
+        text = asyncio.run(_fetch_paper_embed_text(paper_id))
+
+    if not text:
+        logger.error("[Embed] no text for paper_id=%s", paper_id)
+        raise ValueError(f"No text to embed for paper_id={paper_id}")
+
+    try:
+        vector = create_embedding(text)
+    except Exception as exc:
+        logger.exception("[Embed] API failed paper_id=%s", paper_id)
+        raise self.retry(exc=exc)
+
+    try:
+        asyncio.run(_upsert_paper_embedding(paper_id, vector))
+    except Exception as exc:
+        logger.exception("[Embed] MySQL upsert failed paper_id=%s", paper_id)
+        raise self.retry(exc=exc)
+
+    logger.info("[Embed] done paper_id=%s dim=%s", paper_id, len(vector))
+    return {
+        "paper_id": paper_id,
+        "model": settings.EMBEDDING_MODEL,
+        "dim": len(vector),
+    }

--- a/src/backend/db/alembic/versions/0003_add_paper_embedding.py
+++ b/src/backend/db/alembic/versions/0003_add_paper_embedding.py
@@ -1,0 +1,29 @@
+"""add paper_embedding table (MySQL JSON)
+
+Revision ID: 0003_add_paper_embedding
+Revises: 0002_add_md5_hash_file_size
+Create Date: 2026-05-02
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0003_add_paper_embedding"
+down_revision = "0002_add_md5_hash_file_size"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "paper_embedding",
+        sa.Column("paper_id", sa.String(64), sa.ForeignKey("paper.id"), primary_key=True),
+        sa.Column("embedding", sa.JSON(), nullable=False),
+        sa.Column("model_name", sa.String(128), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("paper_embedding")

--- a/src/backend/db/models.py
+++ b/src/backend/db/models.py
@@ -99,6 +99,20 @@ class Paper(Base):
     key_points = relationship("KeyPoints", uselist=False, back_populates="paper")
     folder = relationship("Folder", back_populates="papers")
     tags = relationship("Tag", secondary=paper_tag, back_populates="papers")
+    embedding_row = relationship("PaperEmbedding", uselist=False, back_populates="paper")
+
+
+class PaperEmbedding(Base):
+    """论文向量（Embedding API 结果），存 MySQL JSON，与 paper.id 一对一。"""
+
+    __tablename__ = "paper_embedding"
+
+    paper_id = Column(String(64), ForeignKey("paper.id"), primary_key=True)
+    embedding = Column(JSON, nullable=False)
+    model_name = Column(String(128), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    paper = relationship("Paper", back_populates="embedding_row")
 
 
 class KeyPoints(Base):

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -4,7 +4,6 @@ celery[redis]>=5.4
 redis>=5.0
 SQLAlchemy>=2.0
 alembic>=1.13
-asyncpg>=0.29
 asyncmy>=0.2.11
 python-dotenv>=1.0
 openai>=1.30


### PR DESCRIPTION
摘要
在后端实现论文文本的 Embedding 调用，并将向量写入 MySQL 的 paper_embedding.embedding（JSON），通过 Celery 异步执行；补充 test.py 便于本地验证 HTTP 与可选 Celery 流程。此前基于 PostgreSQL/pgvector 的双库方案已移除，与「仅 MySQL」策略一致。

变更说明
数据模型与迁移：PaperEmbedding 与 paper 一对一；新增 Alembic 0003_add_paper_embedding。
任务：app.tasks.embed_paper，支持传入文本或从 Paper/KeyPoints 拼装文本。