### PR TITLE
feat(backend): 确认后向量化、相似度图谱 API；Windows Celery 默认 solo

### DIFF
--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -15,6 +15,13 @@ DB_POOL_RECYCLE=3600
 REDIS_BROKER_URL=redis://localhost:6379/0
 REDIS_RESULT_BACKEND=redis://localhost:6379/1
 
+# ── SMTP（注册验证码发信；不配则验证码仍写入 Redis，只是不发邮件）────────────────
+# QQ 邮箱示例：SMTP_PASS 为「授权码」，不是 QQ 登录密码（邮箱设置 → 账户 → 开启 SMTP）
+SMTP_HOST=smtp.qq.com
+SMTP_PORT=587
+SMTP_USER=your_email@qq.com
+SMTP_PASS=your_authorization_code
+
 # ── LLM ───────────────────────────────────────────────────────────────────────
 # 选择提供商: deepseek | qwen
 LLM_PROVIDER=deepseek

--- a/src/backend/app/api/routes/graph.py
+++ b/src/backend/app/api/routes/graph.py
@@ -1,0 +1,184 @@
+"""知识图谱：基于论文向量相似度的节点与边（ECharts graph 友好结构）。"""
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.graph_similarity import build_similarity_edges
+from db.crud_graph import list_papers_with_embeddings
+from db.models import PaperStatus
+from db.session import get_db
+from utils.response import error, success
+
+router = APIRouter(prefix="/graph", tags=["graph"])
+
+
+class GraphNodeOut(BaseModel):
+    id: str
+    name: str
+    type: str = "paper"
+    category: int = 0
+    paperInfo: dict[str, Any] = Field(default_factory=dict)
+
+
+class GraphLinkOut(BaseModel):
+    source: str
+    target: str
+    relationType: str = "semantic"
+    label: Optional[str] = None
+
+
+class SimilarityGraphOut(BaseModel):
+    nodes: list[GraphNodeOut]
+    links: list[GraphLinkOut]
+    meta: dict[str, Any]
+
+
+def _build_paper_info(row: dict[str, Any]) -> dict[str, Any]:
+    kp = row["key_points"]
+    st = row.get("status") or ""
+    return {
+        "id": row["paper_id"],
+        "title": row["title"],
+        "authors": row["authors"],
+        "year": row["year"],
+        "status": _paper_status_from_string(st) if st else "pending_parsing",
+        "source": "library",
+        "keyPoints": {
+            "background": kp.get("background", ""),
+            "method": kp.get("method", ""),
+            "innovation": kp.get("innovation", ""),
+            "conclusion": kp.get("conclusion", ""),
+        },
+    }
+
+
+def _paper_status_from_string(s: str) -> str:
+    try:
+        st = PaperStatus(s)
+        return st.name.lower()
+    except ValueError:
+        return s.lower() if s else "pending_parsing"
+
+
+@router.get("/similarity", response_model=None)
+async def similarity_graph(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    folder_id: Optional[str] = Query(None, description="仅包含该文件夹内论文；不传表示用户全部已向量论文"),
+    max_nodes: int = Query(200, ge=1, le=200, description="最多节点数（论文篇数），≤200"),
+    min_similarity: float = Query(0.55, ge=0.0, le=1.0),
+    top_k: int = Query(8, ge=1, le=50, description="每节点保留的最高相似边数"),
+):
+    """
+    返回当前用户文库内、已有向量的论文相似度图。
+
+    - ``max_nodes``: 最多纳入的论文数量（≤200）
+    - ``min_similarity``: 连边最低余弦相似度
+    - ``top_k``: 每个节点最多保留与其它节点的 top-k 相似连边（去重后截断）
+    """
+    if folder_id == "":
+        folder_id = None
+
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    rows = await list_papers_with_embeddings(
+        session,
+        user["id"],
+        folder_id=folder_id,
+        max_nodes=max_nodes,
+    )
+
+    if len(rows) == 0:
+        return success(
+            data={
+                "nodes": [],
+                "links": [],
+                "meta": {
+                    "paper_count": 0,
+                    "reason": "no_embeddings",
+                    "embedding_model": settings.EMBEDDING_MODEL,
+                },
+            },
+            msg="ok",
+            code=0,
+        )
+
+    if len(rows) == 1:
+        r = rows[0]
+        title = r["title"] or ""
+        short = title if len(title) <= 24 else title[:21] + "…"
+        single = SimilarityGraphOut(
+            nodes=[
+                GraphNodeOut(
+                    id=r["paper_id"],
+                    name=short,
+                    type="paper",
+                    category=0,
+                    paperInfo=_build_paper_info(r),
+                )
+            ],
+            links=[],
+            meta={
+                "paper_count": 1,
+                "edge_count": 0,
+                "reason": "need_two_or_more_for_similarity_edges",
+                "embedding_model": settings.EMBEDDING_MODEL,
+            },
+        )
+        return success(data=single.model_dump(), msg="ok", code=0)
+
+    paper_ids = [r["paper_id"] for r in rows]
+    embeddings = [r["embedding"] for r in rows]
+
+    edge_tuples = build_similarity_edges(
+        paper_ids,
+        embeddings,
+        min_similarity=min_similarity,
+        top_k_per_node=top_k,
+    )
+
+    nodes_out: list[GraphNodeOut] = []
+    for r in rows:
+        pid = r["paper_id"]
+        title = r["title"] or ""
+        short = title if len(title) <= 24 else title[:21] + "…"
+        nodes_out.append(
+            GraphNodeOut(
+                id=pid,
+                name=short,
+                type="paper",
+                category=0,
+                paperInfo=_build_paper_info(r),
+            )
+        )
+
+    links_out = [
+        GraphLinkOut(
+            source=a,
+            target=b,
+            relationType="semantic",
+            label=f"相似度 {sim:.2f}",
+        )
+        for a, b, sim in edge_tuples
+    ]
+
+    payload = SimilarityGraphOut(
+        nodes=nodes_out,
+        links=links_out,
+        meta={
+            "paper_count": len(rows),
+            "edge_count": len(links_out),
+            "max_nodes": max_nodes,
+            "min_similarity": min_similarity,
+            "top_k_per_node": top_k,
+            "embedding_model": settings.EMBEDDING_MODEL,
+        },
+    )
+
+    return success(data=payload.model_dump(), msg="ok", code=0)

--- a/src/backend/app/api/routes/papers.py
+++ b/src/backend/app/api/routes/papers.py
@@ -3,14 +3,30 @@ import os
 
 import aiofiles
 from fastapi import APIRouter, Depends, File, Request, UploadFile
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
+from db.crud_keypoints import save_confirmed_key_points
 from db.crud_paper import create_paper, get_paper_by_md5
 from db.session import get_db
 from utils.response import success, error
 
 router = APIRouter(prefix="/papers", tags=["papers"])
+
+
+class KeyPointsIn(BaseModel):
+    background: str = ""
+    method: str = ""
+    innovation: str = ""
+    conclusion: str = ""
+
+
+class PatchKeyPointsBody(BaseModel):
+    """与前端 `saveKeyPointsApi` 一致：{ keyPoints: { background, method, ... } }"""
+
+    model_config = ConfigDict(populate_by_name=True)
+    key_points: KeyPointsIn = Field(alias="keyPoints")
 
 ALLOWED_EXTENSIONS = {".pdf"}
 
@@ -83,6 +99,60 @@ async def upload_pdf(
             "task_id": task.id,
         },
         msg="上传成功，后台解析中",
+        code=0,
+        status_code=200,
+    )
+
+
+@router.patch("/{paper_id}/key-points")
+async def patch_key_points(
+    paper_id: str,
+    request: Request,
+    body: PatchKeyPointsBody,
+    session: AsyncSession = Depends(get_db),
+):
+    """
+    保存四要素并视为「确认」：更新 KeyPoints、Paper.status=CONFIRMED，
+    并异步投递向量化任务 ``embed_paper``。
+    """
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    kp = body.key_points
+    if not (
+        kp.background.strip()
+        and kp.method.strip()
+        and kp.innovation.strip()
+        and kp.conclusion.strip()
+    ):
+        return error(msg="四要素均需填写非空内容", code=400, data=None, status_code=200)
+
+    paper, err = await save_confirmed_key_points(
+        session,
+        paper_id,
+        user["id"],
+        background=kp.background,
+        method=kp.method,
+        innovation=kp.innovation,
+        conclusion=kp.conclusion,
+    )
+    if err:
+        return error(msg=err, code=400, data=None, status_code=200)
+    if paper is None:
+        return error(msg="更新失败", code=500, data=None, status_code=200)
+
+    from app.tasks.embedding_tasks import embed_paper_task
+
+    embed_task = embed_paper_task.delay(paper_id)
+
+    return success(
+        data={
+            "paper_id": paper.id,
+            "status": paper.status.value,
+            "embed_task_id": embed_task.id,
+        },
+        msg="已确认并提交向量化任务",
         code=0,
         status_code=200,
     )

--- a/src/backend/app/celery_app.py
+++ b/src/backend/app/celery_app.py
@@ -1,3 +1,5 @@
+import sys
+
 from celery import Celery
 
 from app.core.config import settings
@@ -17,6 +19,14 @@ celery_app.conf.update(
     enable_utc=False,
     task_track_started=True,
 )
+
+# Windows：prefork/billiard 多进程池易触发 fast_trace_task 等异常；默认 solo 单进程池。
+# Linux/macOS 仍可用命令行覆盖：celery ... -P prefork -c 4
+if sys.platform == "win32":
+    celery_app.conf.update(
+        worker_pool="solo",
+        worker_concurrency=1,
+    )
 
 # Make sure worker auto-loads task modules.
 celery_app.autodiscover_tasks(["app.tasks"])

--- a/src/backend/app/core/graph_similarity.py
+++ b/src/backend/app/core/graph_similarity.py
@@ -1,0 +1,58 @@
+"""基于向量余弦相似度构建边（无第三方数值库依赖）。"""
+
+from __future__ import annotations
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    if len(a) != len(b) or not a:
+        return 0.0
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0 or nb <= 0:
+        return 0.0
+    return dot / (na**0.5 * nb**0.5)
+
+
+def build_similarity_edges(
+    paper_ids: list[str],
+    embeddings: list[list[float]],
+    *,
+    min_similarity: float,
+    top_k_per_node: int,
+    max_edges: int = 1500,
+) -> list[tuple[str, str, float]]:
+    """
+    无向边：每个节点保留与其它节点余弦相似度最高且 >= min_similarity 的 top_k 条，
+    去重后按相似度截断到 max_edges。
+    """
+    n = len(paper_ids)
+    if n < 2:
+        return []
+
+    edges: list[tuple[str, str, float]] = []
+    seen: set[tuple[str, str]] = set()
+
+    for i in range(n):
+        scores: list[tuple[int, float]] = []
+        for j in range(n):
+            if i == j:
+                continue
+            s = cosine_similarity(embeddings[i], embeddings[j])
+            if s >= min_similarity:
+                scores.append((j, s))
+        scores.sort(key=lambda t: -t[1])
+        for j, s in scores[:top_k_per_node]:
+            a, b = paper_ids[i], paper_ids[j]
+            key = tuple(sorted((a, b)))
+            if key in seen:
+                continue
+            seen.add(key)
+            edges.append((a, b, s))
+
+    edges.sort(key=lambda t: -t[2])
+    return edges[:max_edges]

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from app.api.routes.tasks import router as tasks_router
 from app.api.routes.papers import router as papers_router
 from app.api.routes.folders import router as folders_router
+from app.api.routes.graph import router as graph_router
 from app.core.config import settings
 from middleware.jwt_middleware import JWTAuthMiddleware
 from module.user.controller.auth_router import router as auth_router
@@ -33,5 +34,6 @@ def health_check() -> dict:
 app.include_router(tasks_router, prefix=settings.API_PREFIX)
 app.include_router(papers_router, prefix=settings.API_PREFIX)
 app.include_router(folders_router, prefix=settings.API_PREFIX)
+app.include_router(graph_router, prefix=settings.API_PREFIX)
 app.include_router(auth_router)
 app.include_router(user_router)

--- a/src/backend/db/crud_graph.py
+++ b/src/backend/db/crud_graph.py
@@ -1,0 +1,56 @@
+"""图谱：查询用户范围内已生成向量的论文。"""
+
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from db.models import KeyPoints, Paper, PaperEmbedding
+
+
+async def list_papers_with_embeddings(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    folder_id: Optional[str] = None,
+    max_nodes: int = 200,
+) -> list[dict[str, Any]]:
+    """
+    返回当前用户下已有 embedding 的论文（可选按 folder_id 过滤），按向量更新时间倒序，最多 max_nodes 条。
+    每条含 paper 字段、embedding 列表、keypoints 片段（供前端展示）。
+    """
+    q = (
+        select(Paper, PaperEmbedding, KeyPoints)
+        .join(PaperEmbedding, PaperEmbedding.paper_id == Paper.id)
+        .outerjoin(KeyPoints, KeyPoints.paper_id == Paper.id)
+        .where(Paper.user_id == user_id)
+    )
+    if folder_id:
+        q = q.where(Paper.folder_id == folder_id)
+    q = q.order_by(PaperEmbedding.updated_at.desc()).limit(max_nodes)
+
+    result = await session.execute(q)
+    rows = result.all()
+
+    out: list[dict[str, Any]] = []
+    for paper, emb_row, kp in rows:
+        vec = emb_row.embedding
+        if not isinstance(vec, list) or len(vec) < 2:
+            continue
+        vec_f = [float(x) for x in vec]
+        out.append(
+            {
+                "paper_id": paper.id,
+                "title": paper.title or "",
+                "authors": paper.authors or "",
+                "year": paper.year if paper.year is not None else 0,
+                "status": paper.status.value if paper.status else "",
+                "embedding": vec_f,
+                "key_points": {
+                    "background": (kp.background if kp else "") or "",
+                    "method": (kp.methodology if kp else "") or "",
+                    "innovation": (kp.innovation if kp else "") or "",
+                    "conclusion": (kp.conclusion if kp else "") or "",
+                },
+            }
+        )
+    return out

--- a/src/backend/db/crud_keypoints.py
+++ b/src/backend/db/crud_keypoints.py
@@ -1,0 +1,51 @@
+"""论文关键点 CRUD：保存四要素并标记为已确认。"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.crud_paper import get_paper_by_id
+from db.models import KeyPoints, Paper, PaperStatus
+
+
+async def save_confirmed_key_points(
+    session: AsyncSession,
+    paper_id: str,
+    user_id: str,
+    *,
+    background: str,
+    method: str,
+    innovation: str,
+    conclusion: str,
+) -> tuple[Paper | None, str | None]:
+    """
+    更新四要素，将 KeyPoints 标为已确认，Paper.status → CONFIRMED。
+    返回 (paper, None) 成功；(None, 错误信息) 失败。
+    """
+    paper = await get_paper_by_id(session, paper_id)
+    if paper is None or paper.user_id != user_id:
+        return None, "论文不存在或无权访问"
+
+    result = await session.execute(select(KeyPoints).where(KeyPoints.paper_id == paper_id))
+    kp = result.scalar_one_or_none()
+
+    if kp is None:
+        kp = KeyPoints(paper_id=paper_id)
+        session.add(kp)
+
+    kp.background = background.strip()
+    kp.methodology = method.strip()
+    kp.innovation = innovation.strip()
+    kp.conclusion = conclusion.strip()
+    kp.is_confirmed = True
+    kp.confirmed_at = datetime.now(timezone.utc)
+
+    paper.status = PaperStatus.CONFIRMED
+
+    await session.commit()
+    await session.refresh(paper)
+    await session.refresh(kp)
+    return paper, None

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -12,4 +12,6 @@ python-multipart>=0.0.6
 PyMuPDF>=1.23.0
 PyJWT>=2.8
 passlib[bcrypt]>=1.7.4
+# passlib 1.7.4 与 bcrypt>=4.1 不兼容（移除了 __about__）；开发机 hash 命令与登录校验都依赖此组合
+bcrypt>=4.0.1,<4.1.0
 email-validator>=2.3

--- a/src/frontend/src/api/graph.ts
+++ b/src/frontend/src/api/graph.ts
@@ -1,0 +1,28 @@
+import request from '../network/request'
+import type { ApiResponse } from '../types/auth'
+
+/** GET /api/graph/similarity — 基于向量相似度的论文图谱（节点 ≤200） */
+export const fetchSimilarityGraphApi = (params?: {
+  folder_id?: string | null
+  max_nodes?: number
+  min_similarity?: number
+  top_k?: number
+}) =>
+  request.get<ApiResponse<SimilarityGraphPayload>>('/graph/similarity', { params })
+
+export interface SimilarityGraphPayload {
+  nodes: Array<{
+    id: string
+    name: string
+    type: string
+    category: number
+    paperInfo?: Record<string, unknown>
+  }>
+  links: Array<{
+    source: string
+    target: string
+    relationType: string
+    label?: string
+  }>
+  meta: Record<string, unknown>
+}


### PR DESCRIPTION
摘要
实现用户在保存并确认四要素后异步写入向量（MySQL paper_embedding），并提供基于余弦相似度的图谱数据接口（节点上限 200）。同时在 Windows 上将 Celery Worker 默认改为 solo 池，避免 prefork/billiard 下 fast_trace_task 报错；锁定 bcrypt<4.1 与 passlib 兼容。

主要变更
接口：PATCH /api/papers/{paper_id}/key-points；GET /api/graph/similarity（查询参数：folder_id、max_nodes、min_similarity、top_k）。
逻辑：save_confirmed_key_points；按用户与可选文件夹筛选已有向量论文并构图。
Celery：app/celery_app.py 在 win32 下默认 worker_pool=solo、worker_concurrency=1。
依赖：requirements.txt 增加 bcrypt>=4.0.1,<4.1.0。