### PR TITLE
[fix]:修改了paper表的md5_hash的唯一约束改为user_id和md5_hash的联合唯一约束，新增了一个迁移文件

### DIFF
--- a/src/backend/db/alembic/versions/0006_add_uix_user_md5.py
+++ b/src/backend/db/alembic/versions/0006_add_uix_user_md5.py
@@ -1,0 +1,43 @@
+"""
+add user+md5 unique constraint to paper
+
+Revision ID: 0006_add_uix_user_md5
+Revises: 0005_add_paper_source
+Create Date: 2026-05-11
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0006_add_uix_user_md5"
+down_revision = "0005_add_paper_source"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # If there is an existing unique index on md5_hash, drop it.
+    idx_query = sa.text(
+        "SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS "
+        "WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='paper' "
+        "AND COLUMN_NAME='md5_hash' AND NON_UNIQUE=0 LIMIT 1"
+    )
+    res = conn.execute(idx_query)
+    row = res.fetchone()
+    if row:
+        idx_name = row[0]
+        op.execute(sa.text(f"ALTER TABLE `paper` DROP INDEX `{idx_name}`"))
+
+    # Create composite unique constraint (user_id, md5_hash)
+    op.create_unique_constraint('uix_user_md5', 'paper', ['user_id', 'md5_hash'])
+
+
+def downgrade():
+    # Drop composite constraint
+    op.drop_constraint('uix_user_md5', 'paper', type_='unique')
+
+    # Recreate single-column unique constraint on md5_hash
+    op.create_unique_constraint('uq_paper_md5_hash', 'paper', ['md5_hash'])

--- a/src/backend/db/models.py
+++ b/src/backend/db/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Table,
     JSON,
     func,
+    UniqueConstraint,
 )
 from sqlalchemy.orm import relationship
 from .base import Base
@@ -88,7 +89,7 @@ class Paper(Base):
     year = Column(Integer, nullable=True)
     source = Column(String(512), nullable=True)  # 论文出处（期刊/会议名称）
     pdf_path = Column(String(1024), nullable=True)
-    md5_hash = Column(String(64), unique=True, nullable=True)
+    md5_hash = Column(String(64), nullable=True)
     file_size = Column(Integer, nullable=True)
     user_id = Column(String(64), ForeignKey("user.id"), nullable=False)
     folder_id = Column(String(64), ForeignKey("folder.id"), nullable=True)
@@ -101,6 +102,11 @@ class Paper(Base):
     folder = relationship("Folder", back_populates="papers")
     tags = relationship("Tag", secondary=paper_tag, back_populates="papers")
     embedding_row = relationship("PaperEmbedding", uselist=False, back_populates="paper")
+
+    #联合唯一约束（user_id + md5_hash）
+    __table_args__ = (
+        UniqueConstraint("user_id", "md5_hash", name="uix_user_md5"),
+    )
 
 
 class PaperEmbedding(Base):


### PR DESCRIPTION
[fix]:修改了paper表的md5_hash的唯一约束改为user_id和md5_hash的联合唯一约束,新增了一个迁移文件