### PR TITLE
feat(graph): 图谱编辑功能 - 支持自定义节点和边的 CRUD 操作

### DIFF
--- a/src/backend/app/api/routes/graph_edit.py
+++ b/src/backend/app/api/routes/graph_edit.py
@@ -1,0 +1,400 @@
+"""图谱编辑：自定义节点和边的 CRUD 操作"""
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from sqlalchemy import select, delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import GraphNode, GraphEdge
+from db.session import get_db
+from utils.response import error, success
+
+router = APIRouter(prefix="/graph/edit", tags=["graph-edit"])
+
+
+class NodeCreateIn(BaseModel):
+    paper_id: Optional[str] = None
+    name: str = Field(..., min_length=1, max_length=255)
+    node_type: str = Field(default="custom", max_length=50)
+    category: int = Field(default=0, ge=0)
+    properties: Optional[dict[str, Any]] = None
+
+
+class NodeUpdateIn(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=255)
+    node_type: Optional[str] = Field(None, max_length=50)
+    category: Optional[int] = Field(None, ge=0)
+    properties: Optional[dict[str, Any]] = None
+
+
+class EdgeCreateIn(BaseModel):
+    source_id: str = Field(..., min_length=1)
+    target_id: str = Field(..., min_length=1)
+    relation_type: str = Field(default="related", max_length=50)
+    label: Optional[str] = Field(None, max_length=255)
+    properties: Optional[dict[str, Any]] = None
+
+
+class EdgeUpdateIn(BaseModel):
+    relation_type: Optional[str] = Field(None, max_length=50)
+    label: Optional[str] = Field(None, max_length=255)
+    properties: Optional[dict[str, Any]] = None
+
+
+@router.post("/nodes", response_model=None)
+async def create_node(
+    payload: NodeCreateIn,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """创建自定义图谱节点"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    node = GraphNode(
+        user_id=user["id"],
+        paper_id=payload.paper_id,
+        name=payload.name,
+        node_type=payload.node_type,
+        category=payload.category,
+        properties=payload.properties,
+    )
+    
+    session.add(node)
+    await session.commit()
+    await session.refresh(node)
+
+    return success(
+        data={
+            "id": node.id,
+            "name": node.name,
+            "node_type": node.node_type,
+            "category": node.category,
+            "paper_id": node.paper_id,
+            "properties": node.properties,
+        },
+        msg="节点创建成功",
+        code=0,
+    )
+
+
+@router.get("/nodes", response_model=None)
+async def list_nodes(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """获取当前用户的所有自定义图谱节点"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphNode).where(GraphNode.user_id == user["id"]).order_by(GraphNode.created_at.desc())
+    result = await session.execute(q)
+    nodes = result.scalars().all()
+
+    return success(
+        data={
+            "nodes": [
+                {
+                    "id": n.id,
+                    "name": n.name,
+                    "node_type": n.node_type,
+                    "category": n.category,
+                    "paper_id": n.paper_id,
+                    "properties": n.properties,
+                }
+                for n in nodes
+            ],
+            "total": len(nodes),
+        },
+        msg="ok",
+        code=0,
+    )
+
+
+@router.patch("/nodes/{node_id}", response_model=None)
+async def update_node(
+    node_id: str,
+    payload: NodeUpdateIn,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """更新节点属性"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphNode).where(GraphNode.id == node_id, GraphNode.user_id == user["id"])
+    result = await session.execute(q)
+    node = result.scalar_one_or_none()
+
+    if not node:
+        return error(msg="节点不存在", code=404, data=None, status_code=404)
+
+    if payload.name is not None:
+        node.name = payload.name
+    if payload.node_type is not None:
+        node.node_type = payload.node_type
+    if payload.category is not None:
+        node.category = payload.category
+    if payload.properties is not None:
+        node.properties = payload.properties
+
+    await session.commit()
+    await session.refresh(node)
+
+    return success(
+        data={
+            "id": node.id,
+            "name": node.name,
+            "node_type": node.node_type,
+            "category": node.category,
+            "paper_id": node.paper_id,
+            "properties": node.properties,
+        },
+        msg="节点更新成功",
+        code=0,
+    )
+
+
+@router.delete("/nodes/{node_id}", response_model=None)
+async def delete_node(
+    node_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """删除节点，自动级联删除关联的所有边"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphNode).where(GraphNode.id == node_id, GraphNode.user_id == user["id"])
+    result = await session.execute(q)
+    node = result.scalar_one_or_none()
+
+    if not node:
+        return error(msg="节点不存在", code=404, data=None, status_code=404)
+
+    deleted_edges = await session.execute(
+        delete(GraphEdge).where(
+            (GraphEdge.source_id == node_id) | (GraphEdge.target_id == node_id)
+        )
+    )
+    
+    await session.delete(node)
+    await session.commit()
+
+    return success(
+        data={
+            "deleted_node_id": node_id,
+            "deleted_edges_count": deleted_edges.rowcount,
+        },
+        msg=f"节点已删除，同时删除了 {deleted_edges.rowcount} 条关联的边",
+        code=0,
+    )
+
+
+@router.post("/edges", response_model=None)
+async def create_edge(
+    payload: EdgeCreateIn,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """创建节点间的关系边"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    source_q = select(GraphNode).where(GraphNode.id == payload.source_id, GraphNode.user_id == user["id"])
+    source_result = await session.execute(source_q)
+    if not source_result.scalar_one_or_none():
+        return error(msg="源节点不存在", code=404, data=None, status_code=404)
+
+    target_q = select(GraphNode).where(GraphNode.id == payload.target_id, GraphNode.user_id == user["id"])
+    target_result = await session.execute(target_q)
+    if not target_result.scalar_one_or_none():
+        return error(msg="目标节点不存在", code=404, data=None, status_code=404)
+
+    edge = GraphEdge(
+        user_id=user["id"],
+        source_id=payload.source_id,
+        target_id=payload.target_id,
+        relation_type=payload.relation_type,
+        label=payload.label,
+        properties=payload.properties,
+    )
+
+    session.add(edge)
+    await session.commit()
+    await session.refresh(edge)
+
+    return success(
+        data={
+            "id": edge.id,
+            "source_id": edge.source_id,
+            "target_id": edge.target_id,
+            "relation_type": edge.relation_type,
+            "label": edge.label,
+            "properties": edge.properties,
+        },
+        msg="边创建成功",
+        code=0,
+    )
+
+
+@router.get("/edges", response_model=None)
+async def list_edges(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """获取当前用户的所有自定义图谱边"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphEdge).where(GraphEdge.user_id == user["id"]).order_by(GraphEdge.created_at.desc())
+    result = await session.execute(q)
+    edges = result.scalars().all()
+
+    return success(
+        data={
+            "edges": [
+                {
+                    "id": e.id,
+                    "source_id": e.source_id,
+                    "target_id": e.target_id,
+                    "relation_type": e.relation_type,
+                    "label": e.label,
+                    "properties": e.properties,
+                }
+                for e in edges
+            ],
+            "total": len(edges),
+        },
+        msg="ok",
+        code=0,
+    )
+
+
+@router.patch("/edges/{edge_id}", response_model=None)
+async def update_edge(
+    edge_id: str,
+    payload: EdgeUpdateIn,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """更新边的属性"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphEdge).where(GraphEdge.id == edge_id, GraphEdge.user_id == user["id"])
+    result = await session.execute(q)
+    edge = result.scalar_one_or_none()
+
+    if not edge:
+        return error(msg="边不存在", code=404, data=None, status_code=404)
+
+    if payload.relation_type is not None:
+        edge.relation_type = payload.relation_type
+    if payload.label is not None:
+        edge.label = payload.label
+    if payload.properties is not None:
+        edge.properties = payload.properties
+
+    await session.commit()
+    await session.refresh(edge)
+
+    return success(
+        data={
+            "id": edge.id,
+            "source_id": edge.source_id,
+            "target_id": edge.target_id,
+            "relation_type": edge.relation_type,
+            "label": edge.label,
+            "properties": edge.properties,
+        },
+        msg="边更新成功",
+        code=0,
+    )
+
+
+@router.delete("/edges/{edge_id}", response_model=None)
+async def delete_edge(
+    edge_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """删除边"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    q = select(GraphEdge).where(GraphEdge.id == edge_id, GraphEdge.user_id == user["id"])
+    result = await session.execute(q)
+    edge = result.scalar_one_or_none()
+
+    if not edge:
+        return error(msg="边不存在", code=404, data=None, status_code=404)
+
+    await session.delete(edge)
+    await session.commit()
+
+    return success(
+        data={"deleted_edge_id": edge_id},
+        msg="边已删除",
+        code=0,
+    )
+
+
+@router.get("/graph", response_model=None)
+async def get_custom_graph(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+):
+    """获取当前用户的完整自定义图谱"""
+    user = getattr(request.state, "user", None)
+    if not user:
+        return error(msg="未认证", code=401, data=None, status_code=401)
+
+    nodes_q = select(GraphNode).where(GraphNode.user_id == user["id"])
+    nodes_result = await session.execute(nodes_q)
+    nodes = nodes_result.scalars().all()
+
+    edges_q = select(GraphEdge).where(GraphEdge.user_id == user["id"])
+    edges_result = await session.execute(edges_q)
+    edges = edges_result.scalars().all()
+
+    return success(
+        data={
+            "nodes": [
+                {
+                    "id": n.id,
+                    "name": n.name,
+                    "type": n.node_type,
+                    "category": n.category,
+                    "paperInfo": {"id": n.paper_id, "properties": n.properties} if n.paper_id else {"properties": n.properties},
+                }
+                for n in nodes
+            ],
+            "links": [
+                {
+                    "source": e.source_id,
+                    "target": e.target_id,
+                    "relationType": e.relation_type,
+                    "label": e.label,
+                    "properties": e.properties,
+                }
+                for e in edges
+            ],
+            "meta": {
+                "node_count": len(nodes),
+                "edge_count": len(edges),
+            },
+        },
+        msg="ok",
+        code=0,
+    )

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -13,6 +13,8 @@ from app.api.routes.discover import router as discover_router
 from app.api.routes.papers import router as papers_router
 from app.api.routes.folders import router as folders_router
 from app.api.routes.graph import router as graph_router
+from app.api.routes.graph_edit import router as graph_edit_router
+from app.api.routes.notes import router as notes_router
 from app.core.config import settings
 from middleware.jwt_middleware import JWTAuthMiddleware
 from module.user.controller.auth_router import router as auth_router
@@ -24,15 +26,13 @@ app = FastAPI(
     title=settings.APP_NAME,
     description="Scider 学术论文管理系统 API 文档",
     version="1.0.0",
-    docs_url="/docs",  # Swagger UI 路径
-    redoc_url="/redoc",  # ReDoc 路径
-    openapi_url="/openapi.json",  # OpenAPI schema 路径
+    docs_url="/docs",
+    redoc_url="/redoc",
+    openapi_url="/openapi.json",
 )
 
-# ── JWT authentication middleware ──
 app.add_middleware(JWTAuthMiddleware)
 
-# ── CORS 跨域配置（最外层，确保所有响应都带上 CORS 头） ──
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -41,7 +41,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# ── 静态文件服务（用于PDF预览） ──
 UPLOAD_DIR_ABSOLUTE = str(Path(settings.UPLOAD_DIR).resolve())
 os.makedirs(UPLOAD_DIR_ABSOLUTE, exist_ok=True)
 app.mount("/uploads", StaticFiles(directory=UPLOAD_DIR_ABSOLUTE), name="uploads")
@@ -57,9 +56,9 @@ app.include_router(discover_router, prefix=settings.API_PREFIX)
 app.include_router(papers_router, prefix=settings.API_PREFIX)
 app.include_router(folders_router, prefix=settings.API_PREFIX)
 app.include_router(graph_router, prefix=settings.API_PREFIX)
-from app.api.routes.notes import router as notes_router
+app.include_router(graph_edit_router, prefix=settings.API_PREFIX)
+app.include_router(notes_router, prefix=settings.API_PREFIX)
 app.include_router(auth_router)
 app.include_router(user_router)
 app.include_router(avatar_router)
 app.include_router(llm_provider_router)
-app.include_router(notes_router, prefix=settings.API_PREFIX)

--- a/src/backend/db/alembic/versions/0010_add_graph_editing.py
+++ b/src/backend/db/alembic/versions/0010_add_graph_editing.py
@@ -1,0 +1,50 @@
+"""
+add graph_node and graph_edge tables for custom graph editing
+
+Revision ID: 0010_add_graph_editing
+Revises: 0009_add_notes_tables
+Create Date: 2026-05-27
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
+
+
+revision = "0010_add_graph_editing"
+down_revision = "0009_add_notes_tables"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "graph_node",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), sa.ForeignKey("user.id"), nullable=False, index=True),
+        sa.Column("paper_id", sa.String(64), sa.ForeignKey("paper.id"), nullable=True, index=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("node_type", sa.String(50), nullable=False, server_default="custom"),
+        sa.Column("category", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("properties", mysql.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+    )
+
+    op.create_table(
+        "graph_edge",
+        sa.Column("id", sa.String(64), primary_key=True),
+        sa.Column("user_id", sa.String(64), sa.ForeignKey("user.id"), nullable=False, index=True),
+        sa.Column("source_id", sa.String(64), sa.ForeignKey("graph_node.id"), nullable=False, index=True),
+        sa.Column("target_id", sa.String(64), sa.ForeignKey("graph_node.id"), nullable=False, index=True),
+        sa.Column("relation_type", sa.String(50), nullable=False, server_default="related"),
+        sa.Column("label", sa.String(255), nullable=True),
+        sa.Column("properties", mysql.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade():
+    op.drop_table("graph_edge")
+    op.drop_table("graph_node")

--- a/src/backend/db/models.py
+++ b/src/backend/db/models.py
@@ -233,3 +233,42 @@ class NoteSearch(Base):
     paper_title = Column(String(1024), nullable=True)
     content_text = Column(Text, nullable=True)
     updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+
+class GraphNode(Base):
+    """自定义图谱节点表"""
+    __tablename__ = "graph_node"
+
+    id = Column(String(64), primary_key=True, default=gen_id)
+    user_id = Column(String(64), ForeignKey("user.id"), nullable=False, index=True)
+    paper_id = Column(String(64), ForeignKey("paper.id"), nullable=True, index=True)
+    name = Column(String(255), nullable=False)
+    node_type = Column(String(50), nullable=False, server_default="custom")
+    category = Column(Integer, nullable=False, server_default="0")
+    properties = Column(JSON, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    user = relationship("User")
+    paper = relationship("Paper")
+    outgoing_edges = relationship("GraphEdge", foreign_keys="GraphEdge.source_id", back_populates="source_node", cascade="all, delete-orphan")
+    incoming_edges = relationship("GraphEdge", foreign_keys="GraphEdge.target_id", back_populates="target_node", cascade="all, delete-orphan")
+
+
+class GraphEdge(Base):
+    """自定义图谱边表"""
+    __tablename__ = "graph_edge"
+
+    id = Column(String(64), primary_key=True, default=gen_id)
+    user_id = Column(String(64), ForeignKey("user.id"), nullable=False, index=True)
+    source_id = Column(String(64), ForeignKey("graph_node.id"), nullable=False, index=True)
+    target_id = Column(String(64), ForeignKey("graph_node.id"), nullable=False, index=True)
+    relation_type = Column(String(50), nullable=False, server_default="related")
+    label = Column(String(255), nullable=True)
+    properties = Column(JSON, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+    user = relationship("User")
+    source_node = relationship("GraphNode", foreign_keys=[source_id], back_populates="outgoing_edges")
+    target_node = relationship("GraphNode", foreign_keys=[target_id], back_populates="incoming_edges")

--- a/src/frontend/.env.development
+++ b/src/frontend/.env.development
@@ -1,3 +1,3 @@
-VITE_API_BASE_URL=http://39.107.252.200:8000/api
+VITE_API_BASE_URL=http://127.0.0.1:8000/api
 # 关闭模拟模式：必须真实接口通了才行
 VITE_ENABLE_API_FALLBACK=false


### PR DESCRIPTION
# 图谱编辑功能
## 功能概述
实现自定义图谱的完整编辑功能，支持手动添加/删除节点、编辑节点属性、建立或删除节点间关系，完善知识图谱的灵活构建。删除节点时自动级联删除与该节点关联的所有边。
## 主要变更
### 1. 数据库模型 (`db/models.py`)
**GraphNode 表**
- 支持关联到已有论文或创建独立节点
- 可自定义节点类型、分类和属性（JSON 格式）
- 级联删除关联的边
**GraphEdge 表**
- 连接两个节点的关系边
- 支持自定义关系类型、标签和属性（JSON 格式）
### 2. 数据库迁移 (`db/alembic/versions/0010_add_graph_editing.py`)
创建 `graph_node` 和 `graph_edge` 表，包含完整的字段定义和外键约束。
### 3. API 接口 (`app/api/routes/graph_edit.py`)
**节点操作**
- `POST /api/graph/edit/nodes` - 创建节点
- `GET /api/graph/edit/nodes` - 获取所有节点
- `PATCH /api/graph/edit/nodes/{node_id}` - 更新节点属性
- `DELETE /api/graph/edit/nodes/{node_id}` - 删除节点（自动级联删除关联的边）
**边操作**
- `POST /api/graph/edit/edges` - 创建边
- `GET /api/graph/edit/edges` - 获取所有边
- `PATCH /api/graph/edit/edges/{edge_id}` - 更新边属性
- `DELETE /api/graph/edit/edges/{edge_id}` - 删除边
**批量操作**
- `GET /api/graph/edit/graph` - 获取完整图谱（ECharts 友好格式）
### 4. 路由注册 (`app/main.py`)
将图谱编辑路由注册到主应用中。
## 使用示例
### 创建节点
```http
POST /api/graph/edit/nodes
Authorization: Bearer <token>
Content-Type: application/json
{
  "name": "深度学习",
  "node_type": "concept",
  "category": 0,
  "properties": {
    "description": "神经网络相关研究"
  }
}
```
### 创建边
```http
POST /api/graph/edit/edges
Authorization: Bearer <token>
Content-Type: application/json
{
  "source_id": "node_id_1",
  "target_id": "node_id_2",
  "relation_type": "extends",
  "label": "扩展关系",
  "properties": {
    "strength": 0.8
  }
}
```
### 获取完整图谱
```http
GET /api/graph/edit/graph
Authorization: Bearer <token>
```
### 响应示例:
```http
{
  "code": 0,
  "msg": "ok",
  "data": {
    "nodes": [
      {
        "id": "node_id_1",
        "name": "深度学习",
        "type": "concept",
        "category": 0,
        "paperInfo": {
          "properties": {
            "description": "神经网络相关研究"
          }
        }
      }
    ],
    "links": [
      {
        "source": "node_id_1",
        "target": "node_id_2",
        "relationType": "extends",
        "label": "扩展关系",
        "properties": {
          "strength": 0.8
        }
      }
    ],
    "meta": {
      "node_count": 2,
      "edge_count": 1
    }
  }
}
```