### PR TITLE
Pull Request: AI 问答助手场景化测试 + WebSocket 流式聊天

### DIFF
--- a/docs/scenario-test-plan.md
+++ b/docs/scenario-test-plan.md
@@ -1,0 +1,190 @@
+# AI 问答助手场景化测试方案
+
+## 1. 测试目标
+
+对 Scider 系统的 AI 问答功能进行多维度的场景化测试，验证：
+
+| 维度 | 目标 | 衡量指标 |
+|------|------|----------|
+| **回答相关性** | LLM 基于 PDF 正文和笔记的回答是否准确 | 相关性评分 (0-5) + 关键词覆盖 |
+| **响应速度** | 端到端问答延迟 | SLA: ≤5s / ≤10s / ≤30s 达标率 |
+| **流式推送** | WebSocket 逐 token 推送的实时性 | 首 token 延迟 + 推送完整性 |
+| **上下文连贯** | 多轮对话能否引用前文 | 跨轮次引用检测 |
+| **异步可靠性** | Celery 任务状态轮询正确性 | 状态流转完整性 |
+
+## 2. 测试套件架构
+
+```
+tests/
+├── run_qa_scenario_tests.py        # 统一运行入口
+├── test_qa_scenario.py             # 标准问题集 × PDF 场景测试
+├── test_ws_conversation.py         # WebSocket 流式 + 多轮对话测试
+└── test_task_async_push.py         # Celery 异步任务推送测试
+```
+
+## 3. 标准问题集 (13 题)
+
+按认知维度分为 4 类：
+
+### 3.1 事实提取 (FACT-1 ~ FACT-4)
+
+| ID | 问题 | 预期能力 |
+|----|------|----------|
+| FACT-1 | 这篇论文的主要研究问题是什么？ | 提取研究问题 |
+| FACT-2 | 论文提出了什么创新方法？ | 提取方法创新点 |
+| FACT-3 | 论文的实验结果如何？主要性能指标是多少？ | 提取实验数据 |
+| FACT-4 | 论文的研究背景是什么？ | 提取研究背景 |
+
+### 3.2 总结归纳 (SUMM-1 ~ SUMM-3)
+
+| ID | 问题 | 预期能力 |
+|----|------|----------|
+| SUMM-1 | 请用三句话概括这篇论文的核心贡献。 | 摘要总结 |
+| SUMM-2 | 这篇论文的应用场景有哪些？ | 应用归纳 |
+| SUMM-3 | 论文中使用了哪些关键技术或算法？ | 技术归纳 |
+
+### 3.3 批判分析 (CRIT-1 ~ CRIT-3)
+
+| ID | 问题 | 预期能力 |
+|----|------|----------|
+| CRIT-1 | 这篇论文的局限性是什么？ | 局限识别 |
+| CRIT-2 | 论文的实验设计是否合理？为什么？ | 实验评估 |
+| CRIT-3 | 论文的结论是否有足够的数据支撑？ | 结论判断 |
+
+### 3.4 交叉引用 (CROSS-1 ~ CROSS-2)
+
+| ID | 问题 | 预期能力 |
+|----|------|----------|
+| CROSS-1 | 结合我做的笔记，这篇论文和之前阅读的论文有什么联系？ | 笔记关联 |
+| CROSS-2 | 根据论文内容和我的笔记，这个领域下一步的研究方向可能是什么？ | 综合展望 |
+
+## 4. 测试流程
+
+### 4.1 前置条件
+
+```bash
+# 1. 启动后端
+cd src/backend
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+# 2. 启动 Celery Worker（新终端）
+cd src/backend
+celery -A app.worker:celery_app worker --loglevel=info --pool=solo --concurrency=1
+
+# 3. 确保有 CONFIRMED 状态的论文
+#    可通过 Swagger UI 上传 PDF：http://localhost:8000/docs
+```
+
+### 4.2 运行测试
+
+```bash
+# 方式一：统一运行入口（推荐）
+cd src/backend
+python tests/run_qa_scenario_tests.py
+
+# 方式二：选择性运行
+python tests/run_qa_scenario_tests.py --qa-only
+python tests/run_qa_scenario_tests.py --ws-only
+python tests/run_qa_scenario_tests.py --task-only
+
+# 方式三：pytest 单个文件
+pytest tests/test_qa_scenario.py -v --tb=short
+python tests/test_qa_scenario.py          # 直接运行
+
+# WebSocket 测试
+python tests/test_ws_conversation.py
+
+# 异步任务测试
+python tests/test_task_async_push.py
+```
+
+## 5. WebSocket 异步推送
+
+### 5.1 协议设计
+
+**连接**: `ws://localhost:8000/api/ws/chat?token=<JWT>&paper_id=<PAPER_ID>`
+
+**客户端 → 服务端**:
+```json
+{"type": "question", "content": "你的问题"}
+{"type": "clear"}                    // 清除对话历史
+```
+
+**服务端 → 客户端**（流式）:
+```json
+{"type": "token",  "content": "部分回答", "index": 0}
+{"type": "token",  "content": "继续回答", "index": 1}
+{"type": "done",   "content": "完整回答", "sources": [...]}
+{"type": "error",  "content": "错误信息"}
+```
+
+### 5.2 测试覆盖
+
+| 测试项 | 说明 |
+|--------|------|
+| 连接认证 | JWT token 认证、缺少 token 拒绝 |
+| 流式推送 | 逐 token 推送、首 token 延迟、完成信号 |
+| 多轮对话 | 4 轮连续对话、上下文引用检测 |
+| 并发会话 | 3 个 WebSocket 同时连接 |
+| 清除上下文 | clear 命令正确重置历史 |
+| 边界情况 | 空消息、无效 JSON、未知消息类型 |
+| 断线重连 | 断开后重新连接正常工作 |
+
+## 6. 回答相关性评分标准
+
+| 分数 | 标准 |
+|------|------|
+| 5 | 回答准确、完整，有来源引用，关键词全覆盖 |
+| 4 | 回答准确但略简，有来源引用 |
+| 3 | 回答基本相关，缺乏细节或引用 |
+| 2 | 回答部分相关，包含无关内容 |
+| 1 | 回答偏离问题或过于空洞 |
+| 0 | 无法回答或返回错误 |
+
+## 7. 响应时间 SLA
+
+| 阈值 | 目标达标率 | 说明 |
+|------|-----------|------|
+| ≤ 5 秒 | ≥ 60% | 简单问题（事实提取） |
+| ≤ 10 秒 | ≥ 85% | 一般问题（总结归纳） |
+| ≤ 30 秒 | ≥ 95% | 复杂问题（批判分析） |
+
+## 8. 测试报告示例
+
+运行后自动生成结构化的测试报告，包含：
+
+```
+📊 AI 问答场景化测试报告
+=========================================
+📈 总体统计:
+   问题总数: 13
+   成功: 12 / 失败: 1
+   平均响应时间: 4.23s
+   平均相关性评分: 3.8 / 5.0
+
+⏱ 响应时间 SLA:
+   ≤ 5秒: ████████████████░░░░ 80% (10/13)
+   ≤ 10秒: ████████████████████ 100% (13/13)
+
+📂 按类别统计:
+   事实提取: 4/4 通过 | 平均评分 4.2 | 平均响应 2.1s
+   总结归纳: 3/3 通过 | 平均评分 3.8 | 平均响应 3.5s
+   ...
+
+🏆 综合评分: 85.5/100 (等级 B)
+```
+
+## 9. 新增测试编写指南
+
+如需新增测试问题，编辑 `test_qa_scenario.py` 中的 `STANDARD_QUESTIONS` 列表：
+
+```python
+TestQuestion(
+    id="FACT-5",                          # 唯一 ID
+    question="论文的数据集是什么？",       # 问题内容
+    category="fact_extraction",           # 问题类别
+    description="验证能否提取数据集信息",  # 测试意图
+    min_answer_length=30,                 # 最小回答长度
+    expected_keywords=["数据", "训练"],    # 期望关键词
+)
+```

--- a/src/backend/app/api/routes/chat_ws.py
+++ b/src/backend/app/api/routes/chat_ws.py
@@ -1,0 +1,357 @@
+"""
+WebSocket 聊天路由 — 支持流式 AI 问答与多轮对话上下文。
+
+功能：
+  1. 流式推送：LLM 逐 token 输出实时推送到 WebSocket 客户端
+  2. 多轮对话：自动累积历史消息作为上下文
+  3. 任务状态推送：PDF 解析进度实时通知
+
+协议：
+  客户端 → 服务端：JSON 文本帧
+    {"type": "question", "paper_id": "...", "content": "你的问题"}
+    {"type": "clear"}      // 清除当前对话历史
+
+  服务端 → 客户端：JSON 文本帧（流式）
+    {"type": "token",  "content": "部分", "index": 0}
+    {"type": "token",  "content": "回答", "index": 1}
+    {"type": "done",   "content": "完整回答", "sources": [...]}
+    {"type": "error",  "content": "错误信息"}
+    {"type": "status", "content": "task_progress", "data": {"progress": 50}}
+"""
+
+import json
+import logging
+import asyncio
+from typing import Optional
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from app.core.config import settings
+from app.core.prompts import QA_SYSTEM_PROMPT, build_qa_user_prompt
+from db.session import get_db
+from db.crud_note import get_notes_by_paper
+from middleware.jwt_middleware import JWT_SECRET, JWT_ALGORITHM
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/ws", tags=["websocket"])
+
+
+class ConnectionManager:
+    """WebSocket 连接管理器，支持多用户多会话。"""
+
+    def __init__(self):
+        # {user_id: {paper_id: WebSocket}}
+        self._connections: dict[str, dict[str, WebSocket]] = {}
+        # {user_id: {paper_id: [messages]}} 多轮对话历史
+        self._contexts: dict[str, dict[str, list[dict]]] = {}
+
+    async def connect(self, websocket: WebSocket, user_id: str, paper_id: str):
+        await websocket.accept()
+        if user_id not in self._connections:
+            self._connections[user_id] = {}
+            self._contexts[user_id] = {}
+        self._connections[user_id][paper_id] = websocket
+        if paper_id not in self._contexts[user_id]:
+            self._contexts[user_id][paper_id] = []
+        logger.info("WebSocket connected: user=%s paper=%s", user_id, paper_id)
+
+    def disconnect(self, user_id: str, paper_id: str):
+        if user_id in self._connections:
+            self._connections[user_id].pop(paper_id, None)
+            if not self._connections[user_id]:
+                self._connections.pop(user_id, None)
+                self._contexts.pop(user_id, None)
+        logger.info("WebSocket disconnected: user=%s paper=%s", user_id, paper_id)
+
+    async def send_json(self, user_id: str, paper_id: str, data: dict):
+        ws = self._connections.get(user_id, {}).get(paper_id)
+        if ws:
+            await ws.send_text(json.dumps(data, ensure_ascii=False))
+
+    def get_context(self, user_id: str, paper_id: str) -> list:
+        return self._contexts.get(user_id, {}).get(paper_id, [])
+
+    def clear_context(self, user_id: str, paper_id: str):
+        if user_id in self._contexts and paper_id in self._contexts[user_id]:
+            self._contexts[user_id][paper_id] = []
+
+    def add_to_context(self, user_id: str, paper_id: str, role: str, content: str):
+        if user_id in self._contexts and paper_id in self._contexts[user_id]:
+            self._contexts[user_id][paper_id].append({
+                "role": role, "content": content
+            })
+            # 限制历史长度，防止 token 超限
+            max_history = 20
+            if len(self._contexts[user_id][paper_id]) > max_history:
+                self._contexts[user_id][paper_id] = \
+                    self._contexts[user_id][paper_id][-max_history:]
+
+
+manager = ConnectionManager()
+
+
+async def _verify_ws_token(websocket: WebSocket) -> Optional[dict]:
+    """从 WebSocket 查询参数验证 JWT token。"""
+    import jwt
+    token = websocket.query_params.get("token")
+    if not token:
+        await websocket.close(code=4001, reason="Missing token")
+        return None
+    try:
+        payload = jwt.decode(token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+        user_id = payload.get("sub")
+        if not user_id:
+            await websocket.close(code=4001, reason="Invalid token")
+            return None
+        return {"id": user_id, "email": payload.get("email", "")}
+    except jwt.ExpiredSignatureError:
+        await websocket.close(code=4001, reason="Token expired")
+        return None
+    except jwt.InvalidTokenError:
+        await websocket.close(code=4001, reason="Invalid token")
+        return None
+
+
+async def _stream_llm_answer(system_prompt: str, user_prompt: str):
+    """
+    模拟流式 LLM 输出。
+    生产环境可替换为真实的 streaming API 调用。
+    """
+    from app.core.llm_client import _build_client, _active_model
+
+    client = _build_client()
+    model = _active_model()
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            max_tokens=settings.LLM_MAX_TOKENS,
+            temperature=settings.LLM_TEMPERATURE,
+            stream=True,
+        )
+
+        full_content = ""
+        for chunk in response:
+            if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
+                delta = chunk.choices[0].delta.content
+                full_content += delta
+                yield delta
+
+        yield full_content  # 最后返回完整内容用于保存上下文
+    except Exception as e:
+        logger.error("Streaming LLM error: %s", e)
+        raise
+
+
+@router.websocket("/chat")
+async def websocket_chat(websocket: WebSocket):
+    """
+    WebSocket 聊天端点。
+
+    连接方式：
+      ws://localhost:8000/api/ws/chat?token=<JWT_TOKEN>&paper_id=<PAPER_ID>
+
+    消息格式见模块文档。
+    """
+    # ── 1. 认证 ──
+    user = await _verify_ws_token(websocket)
+    if not user:
+        return
+
+    paper_id = websocket.query_params.get("paper_id", "")
+    if not paper_id:
+        await websocket.close(code=4002, reason="Missing paper_id")
+        return
+
+    await manager.connect(websocket, user["id"], paper_id)
+
+    try:
+        while True:
+            raw = await websocket.receive_text()
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await manager.send_json(user["id"], paper_id, {
+                    "type": "error", "content": "无效的 JSON 格式"
+                })
+                continue
+
+            msg_type = msg.get("type", "")
+
+            # ── 清除历史 ──
+            if msg_type == "clear":
+                manager.clear_context(user["id"], paper_id)
+                await manager.send_json(user["id"], paper_id, {
+                    "type": "status", "content": "context_cleared"
+                })
+                continue
+
+            # ── 提问 ──
+            if msg_type == "question":
+                question = msg.get("content", "").strip()
+                if not question:
+                    await manager.send_json(user["id"], paper_id, {
+                        "type": "error", "content": "问题不能为空"
+                    })
+                    continue
+
+                # 保存用户消息到上下文
+                manager.add_to_context(user["id"], paper_id, "user", question)
+
+                try:
+                    # 获取论文和笔记数据
+                    from db.session import get_session
+                    from db.models import Paper
+
+                    async with get_session() as session:
+                        result = await session.execute(
+                            select(Paper).where(
+                                Paper.id == paper_id,
+                                Paper.user_id == user["id"]
+                            )
+                        )
+                        paper = result.scalar_one_or_none()
+
+                        if not paper:
+                            await manager.send_json(user["id"], paper_id, {
+                                "type": "error",
+                                "content": "论文不存在或无权访问"
+                            })
+                            continue
+
+                        notes = await get_notes_by_paper(session, paper_id)
+
+                        if not paper.full_text and not notes:
+                            await manager.send_json(user["id"], paper_id, {
+                                "type": "error",
+                                "content": "论文尚未解析且无笔记，暂无内容可供回答"
+                            })
+                            continue
+
+                    # 构建 prompt（含历史上下文）
+                    history = manager.get_context(user["id"], paper_id)
+                    history_text = ""
+                    if len(history) > 1:  # 至少有一条历史
+                        history_lines = []
+                        for h in history[:-1]:  # 排除当前问题
+                            role = "用户" if h["role"] == "user" else "AI"
+                            history_lines.append(f"{role}: {h['content'][:200]}")
+                        if history_lines:
+                            history_text = "\n".join(history_lines[-6:]) + "\n"
+
+                    user_prompt = build_qa_user_prompt(
+                        title=paper.title,
+                        authors=paper.authors,
+                        full_text=paper.full_text,
+                        notes=notes,
+                        question=f"{history_text}当前问题：{question}",
+                        max_chars=settings.QA_MAX_CHARS,
+                    )
+
+                    # 流式输出
+                    full_answer = ""
+                    index = 0
+                    async for chunk in _stream_llm_answer_stream(
+                        QA_SYSTEM_PROMPT, user_prompt
+                    ):
+                        if index == 0:
+                            # 第一个 yield 是实际的 content
+                            pass
+                        await manager.send_json(user["id"], paper_id, {
+                            "type": "token",
+                            "content": chunk,
+                            "index": index,
+                        })
+                        index += 1
+
+                    # 构建来源
+                    sources = []
+                    if paper.full_text:
+                        excerpt = paper.full_text[:300] + (
+                            "…" if len(paper.full_text) > 300 else ""
+                        )
+                        sources.append({
+                            "type": "full_text",
+                            "excerpt": excerpt,
+                            "page_number": None,
+                        })
+                    for note in notes:
+                        note_excerpt = note.content[:200] + (
+                            "…" if len(note.content) > 200 else ""
+                        )
+                        sources.append({
+                            "type": "note",
+                            "excerpt": note_excerpt,
+                            "page_number": note.page_number,
+                        })
+
+                    # 发送完成信号
+                    await manager.send_json(user["id"], paper_id, {
+                        "type": "done",
+                        "content": full_answer,
+                        "sources": sources,
+                    })
+
+                    # 保存 AI 回答到上下文
+                    manager.add_to_context(
+                        user["id"], paper_id, "assistant", full_answer
+                    )
+
+                except Exception as e:
+                    logger.error("WebSocket chat error: %s", e)
+                    await manager.send_json(user["id"], paper_id, {
+                        "type": "error",
+                        "content": f"AI 服务暂时不可用: {str(e)}"
+                    })
+                continue
+
+            # ── 未知类型 ──
+            await manager.send_json(user["id"], paper_id, {
+                "type": "error", "content": f"未知消息类型: {msg_type}"
+            })
+
+    except WebSocketDisconnect:
+        manager.disconnect(user["id"], paper_id)
+    except Exception as e:
+        logger.error("WebSocket unexpected error: %s", e)
+        manager.disconnect(user["id"], paper_id)
+
+
+async def _stream_llm_answer_stream(system_prompt: str, user_prompt: str):
+    """
+    流式 LLM 输出生成器。
+    使用真正的 streaming API。
+    """
+    from openai import OpenAI
+    from app.core.llm_client import _build_client, _active_model
+
+    client = _build_client()
+    model = _active_model()
+
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        max_tokens=settings.LLM_MAX_TOKENS,
+        temperature=settings.LLM_TEMPERATURE,
+        stream=True,
+    )
+
+    full_content = ""
+    for chunk in response:
+        if chunk.choices and chunk.choices[0].delta and chunk.choices[0].delta.content:
+            delta = chunk.choices[0].delta.content
+            full_content += delta
+            yield delta
+
+    # 用完整内容作为最后一个输出
+    yield full_content

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -15,6 +15,7 @@ from app.api.routes.folders import router as folders_router
 from app.api.routes.graph import router as graph_router
 from app.api.routes.graph_edit import router as graph_edit_router
 from app.api.routes.notes import router as notes_router
+from app.api.routes.chat_ws import router as chat_ws_router
 from app.core.config import settings
 from middleware.jwt_middleware import JWTAuthMiddleware
 from module.user.controller.auth_router import router as auth_router
@@ -58,6 +59,7 @@ app.include_router(folders_router, prefix=settings.API_PREFIX)
 app.include_router(graph_router, prefix=settings.API_PREFIX)
 app.include_router(graph_edit_router, prefix=settings.API_PREFIX)
 app.include_router(notes_router, prefix=settings.API_PREFIX)
+app.include_router(chat_ws_router, prefix=settings.API_PREFIX)
 app.include_router(auth_router)
 app.include_router(user_router)
 app.include_router(avatar_router)

--- a/src/backend/openapi.json
+++ b/src/backend/openapi.json
@@ -2,7 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Scider Backend",
-    "version": "0.1.0"
+    "description": "Scider 学术论文管理系统 API 文档",
+    "version": "1.0.0"
   },
   "paths": {
     "/health": {
@@ -95,10 +96,10 @@
     "/api/discover/search": {
       "get": {
         "tags": [
-          "discover"
+          "论文发现"
         ],
-        "summary": "Search Papers",
-        "description": "调用 Semantic Scholar 检索论文，支持年份/来源类型筛选和排序。",
+        "summary": "检索论文",
+        "description": "调用 Semantic Scholar API 进行关键词检索，支持年份、来源类型筛选和多种排序方式",
         "operationId": "search_papers_api_discover_search_get",
         "parameters": [
           {
@@ -120,11 +121,11 @@
             "schema": {
               "type": "integer",
               "minimum": 0,
-              "description": "分页偏移",
+              "description": "分页偏移量",
               "default": 0,
               "title": "Offset"
             },
-            "description": "分页偏移"
+            "description": "分页偏移量"
           },
           {
             "name": "limit",
@@ -189,10 +190,15 @@
                   "type": "null"
                 }
               ],
-              "description": "来源类型：conference | journal | arXiv",
+              "description": "来源类型筛选",
+              "enum": [
+                "conference",
+                "journal",
+                "arXiv"
+              ],
               "title": "Source Type"
             },
-            "description": "来源类型：conference | journal | arXiv"
+            "description": "来源类型筛选"
           },
           {
             "name": "sort",
@@ -200,11 +206,63 @@
             "required": false,
             "schema": {
               "type": "string",
-              "description": "排序：relevance | citations | date",
+              "description": "排序方式",
+              "enum": [
+                "relevance",
+                "citations",
+                "date"
+              ],
               "default": "relevance",
               "title": "Sort"
             },
-            "description": "排序：relevance | citations | date"
+            "description": "排序方式"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "检索成功",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "502": {
+            "description": "Semantic Scholar API 调用失败"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/discover/recommendations": {
+      "get": {
+        "tags": [
+          "论文发现"
+        ],
+        "summary": "获取论文推荐",
+        "description": "基于用户文库中的论文，通过 Semantic Scholar 搜索相似论文进行推荐",
+        "operationId": "get_recommendations_api_discover_recommendations_get",
+        "parameters": [
+          {
+            "name": "direction",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "推荐方向（预留）",
+              "default": "",
+              "title": "Direction"
+            },
+            "description": "推荐方向（预留）"
           }
         ],
         "responses": {
@@ -232,10 +290,10 @@
     "/api/discover/import": {
       "post": {
         "tags": [
-          "discover"
+          "论文发现"
         ],
-        "summary": "Import Paper",
-        "description": "单篇导入：创建 Paper 记录并触发异步解析任务。\n若同一用户已存在相同 DOI 的论文，返回 409。",
+        "summary": "导入论文到文库",
+        "description": "将检索到的论文导入到用户文库，自动下载 PDF（如有）并触发异步解析任务",
         "operationId": "import_paper_api_discover_import_post",
         "requestBody": {
           "content": {
@@ -247,6 +305,55 @@
           },
           "required": true
         },
+        "responses": {
+          "200": {
+            "description": "导入成功",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "409": {
+            "description": "论文已存在于文库中"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/discover/references/by-paper/{paper_id}": {
+      "get": {
+        "tags": [
+          "论文发现"
+        ],
+        "summary": "根据本地论文 ID 获取参考文献",
+        "description": "根据本地论文 ID 查找 DOI 后调用 Semantic Scholar 获取参考文献（上游）",
+        "operationId": "get_references_by_paper_api_discover_references_by_paper__paper_id__get",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "本地论文 ID",
+              "title": "Paper Id"
+            },
+            "description": "本地论文 ID"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -269,24 +376,27 @@
         }
       }
     },
-    "/api/discover/import/bulk": {
-      "post": {
+    "/api/discover/citations/by-paper/{paper_id}": {
+      "get": {
         "tags": [
-          "discover"
+          "论文发现"
         ],
-        "summary": "Bulk Import Papers",
-        "description": "批量导入，单次上限 20 篇。\n逐篇检查重复，跳过已存在的论文；其余逐篇创建记录并派发 Celery 任务。\n使用 flush() 在单个事务内获取 paper.id，最后统一 commit。",
-        "operationId": "bulk_import_papers_api_discover_import_bulk_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/BulkImportRequest"
-              }
-            }
-          },
-          "required": true
-        },
+        "summary": "根据本地论文 ID 获取引用文献",
+        "description": "根据本地论文 ID 查找 DOI 后调用 Semantic Scholar 获取引用文献（下游）",
+        "operationId": "get_citations_by_paper_api_discover_citations_by_paper__paper_id__get",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "本地论文 ID",
+              "title": "Paper Id"
+            },
+            "description": "本地论文 ID"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -312,10 +422,10 @@
     "/api/discover/references/{semantic_id}": {
       "get": {
         "tags": [
-          "discover"
+          "论文发现"
         ],
-        "summary": "Get References",
-        "description": "获取该论文的参考文献（上游），并标注哪些已在用户文库中。",
+        "summary": "获取参考文献",
+        "description": "获取指定论文的参考文献列表（该论文引用的文献，即上游），并标注哪些已在用户文库中",
         "operationId": "get_references_api_discover_references__semantic_id__get",
         "parameters": [
           {
@@ -324,19 +434,107 @@
             "required": true,
             "schema": {
               "type": "string",
+              "description": "Semantic Scholar 论文 ID",
               "title": "Semantic Id"
+            },
+            "description": "Semantic Scholar 论文 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "获取成功",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
             }
           },
+          "401": {
+            "description": "未认证"
+          },
+          "502": {
+            "description": "Semantic Scholar API 调用失败"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/discover/citations/{semantic_id}": {
+      "get": {
+        "tags": [
+          "论文发现"
+        ],
+        "summary": "获取引用文献",
+        "description": "获取引用指定论文的文献列表（下游），并标注哪些已在用户文库中",
+        "operationId": "get_citations_api_discover_citations__semantic_id__get",
+        "parameters": [
           {
-            "name": "user_id",
-            "in": "query",
+            "name": "semantic_id",
+            "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "当前用户 ID",
-              "title": "User Id"
+              "description": "Semantic Scholar 论文 ID",
+              "title": "Semantic Id"
             },
-            "description": "当前用户 ID"
+            "description": "Semantic Scholar 论文 ID"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "获取成功",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "401": {
+            "description": "未认证"
+          },
+          "502": {
+            "description": "Semantic Scholar API 调用失败"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/": {
+      "get": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "List Papers",
+        "description": "获取当前用户的论文列表",
+        "operationId": "list_papers_api_papers__get",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
           }
         ],
         "responses": {
@@ -361,34 +559,2628 @@
         }
       }
     },
-    "/api/discover/citations/{semantic_id}": {
+    "/api/papers/{paper_id}": {
       "get": {
         "tags": [
-          "discover"
+          "papers"
         ],
-        "summary": "Get Citations",
-        "description": "获取引用该论文的文献（下游），并标注哪些已在用户文库中。",
-        "operationId": "get_citations_api_discover_citations__semantic_id__get",
+        "summary": "Get Paper Detail",
+        "description": "获取单个论文详情",
+        "operationId": "get_paper_detail_api_papers__paper_id__get",
         "parameters": [
           {
-            "name": "semantic_id",
+            "name": "paper_id",
             "in": "path",
             "required": true,
             "schema": {
               "type": "string",
-              "title": "Semantic Id"
+              "title": "Paper Id"
             }
           },
           {
-            "name": "user_id",
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Delete Paper Endpoint",
+        "description": "删除论文（级联删除关联数据）",
+        "operationId": "delete_paper_endpoint_api_papers__paper_id__delete",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/pdf-info": {
+      "get": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Get Paper Pdf Info",
+        "description": "获取论文PDF预览信息",
+        "operationId": "get_paper_pdf_info_api_papers__paper_id__pdf_info_get",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/notes": {
+      "get": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Get Paper Notes",
+        "description": "获取论文的笔记列表",
+        "operationId": "get_paper_notes_api_papers__paper_id__notes_get",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Create Paper Note",
+        "description": "创建论文笔记",
+        "operationId": "create_paper_note_api_papers__paper_id__notes_post",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/notes/{note_id}": {
+      "patch": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Update Paper Note",
+        "description": "更新论文笔记",
+        "operationId": "update_paper_note_api_papers__paper_id__notes__note_id__patch",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Note Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/upload": {
+      "post": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Upload Pdf",
+        "operationId": "upload_pdf_api_papers_upload_post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_pdf_api_papers_upload_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/key-points": {
+      "patch": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Patch Key Points",
+        "description": "保存四要素并视为「确认」：更新 KeyPoints、Paper.status=CONFIRMED，\n并异步投递向量化任务 ``embed_paper``。",
+        "operationId": "patch_key_points_api_papers__paper_id__key_points_patch",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PatchKeyPointsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/pdf-file": {
+      "get": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Get Pdf File",
+        "description": "获取PDF文件流，设置 Content-Disposition: inline 防止浏览器下载。",
+        "operationId": "get_pdf_file_api_papers__paper_id__pdf_file_get",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/search": {
+      "post": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Search In Paper",
+        "description": "在指定论文中搜索关键词（基于 MySQL FULLTEXT + ngram）\n\n- 支持中文/英文混合搜索\n- 返回匹配片段和高亮标记\n- 可限定特定页码搜索",
+        "operationId": "search_in_paper_api_papers__paper_id__search_post",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/papers/{paper_id}/ask": {
+      "post": {
+        "tags": [
+          "papers"
+        ],
+        "summary": "Ask Paper Question",
+        "description": "基于论文全文和用户笔记，用 LLM 回答自然语言问题。",
+        "operationId": "ask_paper_question_api_papers__paper_id__ask_post",
+        "parameters": [
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AskRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/": {
+      "post": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Create",
+        "operationId": "create_api_folders__post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFolderIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "List Folders",
+        "operationId": "list_folders_api_folders__get",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/{folder_id}": {
+      "get": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Get Folder",
+        "operationId": "get_folder_api_folders__folder_id__get",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Rename",
+        "operationId": "rename_api_folders__folder_id__patch",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameFolderIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Delete",
+        "operationId": "delete_api_folders__folder_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/{folder_id}/papers": {
+      "post": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Add Paper",
+        "operationId": "add_paper_api_folders__folder_id__papers_post",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddPaperIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/{folder_id}/papers/batch": {
+      "post": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Batch Add Papers",
+        "description": "批量添加论文到文件夹",
+        "operationId": "batch_add_papers_api_folders__folder_id__papers_batch_post",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchAddPapersIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/folders/{folder_id}/papers/{paper_id}": {
+      "delete": {
+        "tags": [
+          "folders"
+        ],
+        "summary": "Remove Paper",
+        "operationId": "remove_paper_api_folders__folder_id__papers__paper_id__delete",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Folder Id"
+            }
+          },
+          {
+            "name": "paper_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Paper Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/similarity": {
+      "get": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "Similarity Graph",
+        "description": "返回当前用户文库内、已有向量的论文相似度图。\n\n- ``max_nodes``: 最多纳入的论文数量（≤200）\n- ``min_similarity``: 连边最低余弦相似度\n- ``top_k``: 每个节点最多保留与其它节点的 top-k 相似连边（去重后截断）",
+        "operationId": "similarity_graph_api_graph_similarity_get",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仅包含该文件夹内论文；不传表示用户全部已向量论文",
+              "title": "Folder Id"
+            },
+            "description": "仅包含该文件夹内论文；不传表示用户全部已向量论文"
+          },
+          {
+            "name": "max_nodes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 200,
+              "minimum": 1,
+              "description": "最多节点数（论文篇数），≤200",
+              "default": 200,
+              "title": "Max Nodes"
+            },
+            "description": "最多节点数（论文篇数），≤200"
+          },
+          {
+            "name": "min_similarity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "default": 0.55,
+              "title": "Min Similarity"
+            }
+          },
+          {
+            "name": "top_k",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 50,
+              "minimum": 1,
+              "description": "每节点保留的最高相似边数",
+              "default": 8,
+              "title": "Top K"
+            },
+            "description": "每节点保留的最高相似边数"
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/embeddings/trigger-batch": {
+      "post": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "Trigger Batch Embeddings",
+        "description": "对当前用户下已有四要素但尚无向量的论文，批量投递向量化任务。\n用于首次部署向量功能后补发历史论文的向量任务。",
+        "operationId": "trigger_batch_embeddings_api_graph_embeddings_trigger_batch_post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/llm-structure": {
+      "get": {
+        "tags": [
+          "graph"
+        ],
+        "summary": "Llm Graph Structure",
+        "description": "基于 LLM 分析论文四要素，生成主题聚类和语义关系边。\n\n- 仅包含状态为 CONFIRMED 的论文（已确认四要素）\n- LLM 自动识别研究主题并聚类（2-6 个主题）\n- LLM 生成语义关系边（extends/applies/compares/related）\n- 返回 ECharts graph 友好的节点和边结构，节点按主题分类（category 字段）\n\n**注意**：此接口调用 LLM，响应时间较长（10-30秒），建议前端设置较长超时。",
+        "operationId": "llm_graph_structure_api_graph_llm_structure_get",
+        "parameters": [
+          {
+            "name": "folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "仅包含该文件夹内论文；不传表示用户全部已确认论文",
+              "title": "Folder Id"
+            },
+            "description": "仅包含该文件夹内论文；不传表示用户全部已确认论文"
+          },
+          {
+            "name": "max_nodes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "maximum": 100,
+              "minimum": 1,
+              "description": "最多节点数（论文篇数），≤100",
+              "default": 50,
+              "title": "Max Nodes"
+            },
+            "description": "最多节点数（论文篇数），≤100"
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/edit/nodes": {
+      "post": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Create Node",
+        "description": "创建自定义图谱节点",
+        "operationId": "create_node_api_graph_edit_nodes_post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NodeCreateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "List Nodes",
+        "description": "获取当前用户的所有自定义图谱节点",
+        "operationId": "list_nodes_api_graph_edit_nodes_get",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/edit/nodes/{node_id}": {
+      "patch": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Update Node",
+        "description": "更新节点属性",
+        "operationId": "update_node_api_graph_edit_nodes__node_id__patch",
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Node Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NodeUpdateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Delete Node",
+        "description": "删除节点，自动级联删除关联的所有边",
+        "operationId": "delete_node_api_graph_edit_nodes__node_id__delete",
+        "parameters": [
+          {
+            "name": "node_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Node Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/edit/edges": {
+      "post": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Create Edge",
+        "description": "创建节点间的关系边",
+        "operationId": "create_edge_api_graph_edit_edges_post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EdgeCreateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "List Edges",
+        "description": "获取当前用户的所有自定义图谱边",
+        "operationId": "list_edges_api_graph_edit_edges_get",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/edit/edges/{edge_id}": {
+      "patch": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Update Edge",
+        "description": "更新边的属性",
+        "operationId": "update_edge_api_graph_edit_edges__edge_id__patch",
+        "parameters": [
+          {
+            "name": "edge_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Edge Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EdgeUpdateIn"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Delete Edge",
+        "description": "删除边",
+        "operationId": "delete_edge_api_graph_edit_edges__edge_id__delete",
+        "parameters": [
+          {
+            "name": "edge_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Edge Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/graph/edit/graph": {
+      "get": {
+        "tags": [
+          "graph-edit"
+        ],
+        "summary": "Get Custom Graph",
+        "description": "获取当前用户的完整自定义图谱",
+        "operationId": "get_custom_graph_api_graph_edit_graph_get",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notes/uploads": {
+      "post": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Upload Note Image",
+        "operationId": "upload_note_image_api_notes_uploads_post",
+        "parameters": [
+          {
+            "name": "paperId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Paperid"
+            }
+          },
+          {
+            "name": "noteId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Noteid"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_note_image_api_notes_uploads_post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notes/": {
+      "post": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Create Note",
+        "operationId": "create_note_api_notes__post",
+        "parameters": [
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateNoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "List Notes",
+        "operationId": "list_notes_api_notes__get",
+        "parameters": [
+          {
+            "name": "paperId",
             "in": "query",
             "required": true,
             "schema": {
               "type": "string",
-              "description": "当前用户 ID",
-              "title": "User Id"
-            },
-            "description": "当前用户 ID"
+              "title": "Paperid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Pagesize"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notes/search": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Search",
+        "operationId": "search_api_notes_search_get",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Q"
+            }
+          },
+          {
+            "name": "paperId",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Paperid"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1,
+              "title": "Page"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "title": "Pagesize"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notes/{note_id}/images": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Get Note Images",
+        "operationId": "get_note_images_api_notes__note_id__images_get",
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Note Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/notes/{note_id}": {
+      "get": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Get Note",
+        "operationId": "get_note_api_notes__note_id__get",
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Note Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Patch Note",
+        "operationId": "patch_note_api_notes__note_id__patch",
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Note Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNoteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "notes"
+        ],
+        "summary": "Remove Note",
+        "operationId": "remove_note_api_notes__note_id__delete",
+        "parameters": [
+          {
+            "name": "note_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Note Id"
+            }
+          },
+          {
+            "name": "echo",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Echo"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/register": {
+      "post": {
+        "summary": "Register",
+        "operationId": "register_api_user_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/login": {
+      "post": {
+        "summary": "Login",
+        "operationId": "login_api_user_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/token": {
+      "post": {
+        "summary": "Token",
+        "operationId": "token_api_user_token_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_token_api_user_token_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/send-code": {
+      "post": {
+        "summary": "Send Code",
+        "operationId": "send_code_api_user_send_code_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendCodeIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/change-password": {
+      "post": {
+        "summary": "Change Password",
+        "operationId": "change_password_api_user_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChangePasswordIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/me": {
+      "get": {
+        "summary": "Me",
+        "operationId": "me_api_user_me_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update Me",
+        "operationId": "update_me_api_user_me_patch",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateNameIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/avatar": {
+      "get": {
+        "summary": "Get Avatar",
+        "description": "返回当前用户的 avatarUrl（若存在）。",
+        "operationId": "get_avatar_api_user_avatar_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Upload Avatar",
+        "description": "上传或更新当前登录用户的头像。\n- 接收 multipart/form-data 字段 `file`，仅接受图片（后端简单校验后缀）\n- 返回 avatarUrl",
+        "operationId": "upload_avatar_api_user_avatar_post",
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_avatar_api_user_avatar_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Remove Avatar",
+        "description": "删除当前用户头像（DB 字段与磁盘文件）。",
+        "operationId": "remove_avatar_api_user_avatar_delete",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/llm-providers": {
+      "get": {
+        "summary": "Api List Providers",
+        "description": "仅返回当前登录用户所拥有的 LLM provider 列表（只包含用户创建的记录）。\n- 需要登录：若未登录返回 401。\n- 仅返回 `provider.user_id == current_user.id` 的记录，不包含全局配置。",
+        "operationId": "api_list_providers_api_user_llm_providers_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Api Create Provider",
+        "description": "创建 provider：普通用户只能为自己创建，不允许指定他人 user_id。",
+        "operationId": "api_create_provider_api_user_llm_providers_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMProviderIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/user/llm-providers/{provider_id}": {
+      "get": {
+        "summary": "Api Get Provider",
+        "operationId": "api_get_provider_api_user_llm_providers__provider_id__get",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Api Update Provider",
+        "description": "更新 provider：仅允许 owner 修改；全局 provider（user_id is None）暂不允许普通用户修改。",
+        "operationId": "api_update_provider_api_user_llm_providers__provider_id__patch",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMProviderUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Api Delete Provider",
+        "description": "删除 provider：仅 owner 或 admin 可删；全局 provider 需 admin。",
+        "operationId": "api_delete_provider_api_user_llm_providers__provider_id__delete",
+        "parameters": [
+          {
+            "name": "provider_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Provider Id"
+            }
           }
         ],
         "responses": {
@@ -416,26 +3208,326 @@
   },
   "components": {
     "schemas": {
-      "BulkImportRequest": {
+      "AddPaperIn": {
         "properties": {
-          "papers": {
-            "items": {
-              "$ref": "#/components/schemas/ImportRequest"
-            },
-            "type": "array",
-            "title": "Papers"
-          },
-          "user_id": {
+          "paper_id": {
             "type": "string",
-            "title": "User Id"
+            "title": "Paper Id"
           }
         },
         "type": "object",
         "required": [
-          "papers",
-          "user_id"
+          "paper_id"
         ],
-        "title": "BulkImportRequest"
+        "title": "AddPaperIn"
+      },
+      "AskRequest": {
+        "properties": {
+          "question": {
+            "type": "string",
+            "maxLength": 2000,
+            "minLength": 1,
+            "title": "Question"
+          }
+        },
+        "type": "object",
+        "required": [
+          "question"
+        ],
+        "title": "AskRequest"
+      },
+      "BatchAddPapersIn": {
+        "properties": {
+          "paper_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Paper Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "paper_ids"
+        ],
+        "title": "BatchAddPapersIn"
+      },
+      "Body_token_api_user_token_post": {
+        "properties": {
+          "grant_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^password$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "username": {
+            "type": "string",
+            "title": "Username"
+          },
+          "password": {
+            "type": "string",
+            "format": "password",
+            "title": "Password"
+          },
+          "scope": {
+            "type": "string",
+            "title": "Scope",
+            "default": ""
+          },
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "format": "password",
+            "title": "Client Secret"
+          }
+        },
+        "type": "object",
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_token_api_user_token_post"
+      },
+      "Body_upload_avatar_api_user_avatar_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_avatar_api_user_avatar_post"
+      },
+      "Body_upload_note_image_api_notes_uploads_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_note_image_api_notes_uploads_post"
+      },
+      "Body_upload_pdf_api_papers_upload_post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "contentMediaType": "application/octet-stream",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_pdf_api_papers_upload_post"
+      },
+      "ChangePasswordIn": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "new_password": {
+            "type": "string",
+            "title": "New Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "code",
+          "new_password"
+        ],
+        "title": "ChangePasswordIn"
+      },
+      "CreateFolderIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "CreateFolderIn"
+      },
+      "CreateNoteRequest": {
+        "properties": {
+          "paperId": {
+            "type": "string",
+            "title": "Paperid"
+          },
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "contentHtml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contenthtml"
+          },
+          "contentFormat": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contentformat",
+            "default": "html"
+          }
+        },
+        "type": "object",
+        "required": [
+          "paperId"
+        ],
+        "title": "CreateNoteRequest"
+      },
+      "EdgeCreateIn": {
+        "properties": {
+          "source_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Source Id"
+          },
+          "target_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Target Id"
+          },
+          "relation_type": {
+            "type": "string",
+            "maxLength": 50,
+            "title": "Relation Type",
+            "default": "related"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Properties"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_id",
+          "target_id"
+        ],
+        "title": "EdgeCreateIn"
+      },
+      "EdgeUpdateIn": {
+        "properties": {
+          "relation_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 50
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Relation Type"
+          },
+          "label": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Label"
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Properties"
+          }
+        },
+        "type": "object",
+        "title": "EdgeUpdateIn"
       },
       "HTTPValidationError": {
         "properties": {
@@ -454,7 +3546,8 @@
         "properties": {
           "title": {
             "type": "string",
-            "title": "Title"
+            "title": "Title",
+            "description": "论文标题"
           },
           "authors": {
             "anyOf": [
@@ -465,7 +3558,8 @@
                 "type": "null"
               }
             ],
-            "title": "Authors"
+            "title": "Authors",
+            "description": "作者列表（逗号分隔）"
           },
           "abstract": {
             "anyOf": [
@@ -476,7 +3570,8 @@
                 "type": "null"
               }
             ],
-            "title": "Abstract"
+            "title": "Abstract",
+            "description": "摘要"
           },
           "doi": {
             "anyOf": [
@@ -487,7 +3582,8 @@
                 "type": "null"
               }
             ],
-            "title": "Doi"
+            "title": "Doi",
+            "description": "DOI"
           },
           "year": {
             "anyOf": [
@@ -498,7 +3594,8 @@
                 "type": "null"
               }
             ],
-            "title": "Year"
+            "title": "Year",
+            "description": "发表年份"
           },
           "venue": {
             "anyOf": [
@@ -509,19 +3606,494 @@
                 "type": "null"
               }
             ],
-            "title": "Venue"
+            "title": "Venue",
+            "description": "发表会议/期刊"
+          },
+          "pdf_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pdf Url",
+            "description": "PDF 下载链接"
+          }
+        },
+        "type": "object",
+        "required": [
+          "title"
+        ],
+        "title": "ImportRequest",
+        "description": "导入论文请求体"
+      },
+      "KeyPointsIn": {
+        "properties": {
+          "background": {
+            "type": "string",
+            "title": "Background",
+            "default": ""
+          },
+          "method": {
+            "type": "string",
+            "title": "Method",
+            "default": ""
+          },
+          "innovation": {
+            "type": "string",
+            "title": "Innovation",
+            "default": ""
+          },
+          "conclusion": {
+            "type": "string",
+            "title": "Conclusion",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "KeyPointsIn",
+        "description": "前端和 LLM 统一使用 methodology。接收 method（兼容旧前端）。"
+      },
+      "LLMProviderIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "default_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Model"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled",
+            "default": true
           },
           "user_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "User Id"
           }
         },
         "type": "object",
         "required": [
-          "title",
-          "user_id"
+          "name",
+          "provider"
         ],
-        "title": "ImportRequest"
+        "title": "LLMProviderIn"
+      },
+      "LLMProviderUpdate": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "base_url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Base Url"
+          },
+          "api_key": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Api Key"
+          },
+          "default_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Model"
+          },
+          "enabled": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Enabled"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "type": "object",
+        "title": "LLMProviderUpdate",
+        "description": "用于 PATCH 的部分更新模型：所有字段均可选以支持部分更新请求。"
+      },
+      "LoginIn": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "LoginIn"
+      },
+      "NodeCreateIn": {
+        "properties": {
+          "paper_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Paper Id"
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "minLength": 1,
+            "title": "Name"
+          },
+          "node_type": {
+            "type": "string",
+            "maxLength": 50,
+            "title": "Node Type",
+            "default": "custom"
+          },
+          "category": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Category",
+            "default": 0
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Properties"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "NodeCreateIn"
+      },
+      "NodeUpdateIn": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 255,
+                "minLength": 1
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "node_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 50
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Node Type"
+          },
+          "category": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "minimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Category"
+          },
+          "properties": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Properties"
+          }
+        },
+        "type": "object",
+        "title": "NodeUpdateIn"
+      },
+      "PatchKeyPointsBody": {
+        "properties": {
+          "keyPoints": {
+            "$ref": "#/components/schemas/KeyPointsIn"
+          }
+        },
+        "type": "object",
+        "required": [
+          "keyPoints"
+        ],
+        "title": "PatchKeyPointsBody"
+      },
+      "RegisterIn": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email",
+          "password",
+          "code"
+        ],
+        "title": "RegisterIn"
+      },
+      "RenameFolderIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "RenameFolderIn"
+      },
+      "SearchRequest": {
+        "properties": {
+          "keyword": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Keyword",
+            "description": "搜索关键词"
+          },
+          "page_number": {
+            "type": "integer",
+            "minimum": 1.0,
+            "title": "Page Number",
+            "description": "限定页码（可选）"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 200.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "description": "返回结果数量上限",
+            "default": 50
+          }
+        },
+        "type": "object",
+        "required": [
+          "keyword"
+        ],
+        "title": "SearchRequest",
+        "description": "搜索请求模型"
+      },
+      "SendCodeIn": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "title": "SendCodeIn"
+      },
+      "UpdateNameIn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "title": "UpdateNameIn"
+      },
+      "UpdateNoteRequest": {
+        "properties": {
+          "title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Title"
+          },
+          "contentHtml": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contenthtml"
+          },
+          "contentFormat": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Contentformat"
+          }
+        },
+        "type": "object",
+        "title": "UpdateNoteRequest"
       },
       "ValidationError": {
         "properties": {

--- a/src/backend/readme.md
+++ b/src/backend/readme.md
@@ -268,6 +268,114 @@ curl -X POST http://127.0.0.1:8000/api/papers/upload \
 
 ---
 
-测试
+## 10. AI 问答场景化测试
+
+项目包含一套完整的 AI 问答场景化测试套件，覆盖标准问题集、WebSocket 流式推送、多轮对话上下文连贯性、以及 Celery 异步任务状态轮询。
+
+### 10.1 测试套件一览
+
+| 文件 | 说明 | 测试项 |
+|------|------|--------|
+| `tests/test_qa_scenario.py` | 标准问题集测试 | 13 道题 × 4 维度（事实提取/总结归纳/批判分析/交叉引用），含相关性评分 & 响应时间 SLA |
+| `tests/test_ws_conversation.py` | WebSocket 流式 + 多轮对话测试 | 7 项（连接/流式推送/上下文连贯/并发/清除历史/边界/断线重连） |
+| `tests/test_task_async_push.py` | Celery 异步任务推送测试 | Ping 任务轮询、状态流转、边界情况 |
+| `tests/run_qa_scenario_tests.py` | 统一运行入口 | 选择性/全量运行 |
+
+### 10.2 前置条件
+
+```bash
+# 1. 启动基础设施（MySQL + Redis）
+cd src/backend
+docker compose up -d mysql redis
+
+# 2. 执行数据库迁移
+cd src/backend/db
+alembic upgrade head
+
+# 3. 启动 FastAPI 后端
+cd src/backend
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+
+# 4. 启动 Celery Worker（新终端）
+cd src/backend
+celery -A app.worker:celery_app worker --loglevel=info --pool=solo --concurrency=1
+
+# 5. 确保有已解析完成的论文（通过前端上传 PDF，等待状态变为 CONFIRMED）
+```
+
+### 10.3 运行测试
+
+```bash
+# 统一运行（所有测试）
+cd src/backend
+python tests/run_qa_scenario_tests.py
+
+# 选择性运行
+python tests/run_qa_scenario_tests.py --qa-only    # 仅标准问题集
+python tests/run_qa_scenario_tests.py --ws-only     # 仅 WebSocket 测试
+python tests/run_qa_scenario_tests.py --task-only   # 仅异步任务测试
+
+# 或直接运行单个文件
+python tests/test_qa_scenario.py
+python tests/test_ws_conversation.py
+python tests/test_task_async_push.py
+
+# 也可以用 pytest（标准问题集）
+pytest tests/test_qa_scenario.py -v --tb=short
+```
+
+### 10.4 WebSocket 流式对话协议
+
+**连接地址：**
+```
+ws://localhost:8000/api/ws/chat?token=<JWT_TOKEN>&paper_id=<PAPER_ID>
+```
+
+**消息格式：**
+
+| 方向 | type | 说明 |
+|------|------|------|
+| 客户端 → 服务端 | `question` | `{"type":"question","content":"你的问题"}` |
+| 客户端 → 服务端 | `clear` | `{"type":"clear"}` 清除对话历史 |
+| 服务端 → 客户端 | `token` | `{"type":"token","content":"部分回答","index":0}` 流式推送 |
+| 服务端 → 客户端 | `done` | `{"type":"done","content":"完整回答","sources":[...]}` 完成 |
+| 服务端 → 客户端 | `error` | `{"type":"error","content":"错误信息"}` |
+
+### 10.5 标准问题集分类
+
+| 类别 | 题数 | 示例 |
+|------|------|------|
+| 事实提取 (FACT) | 4 | "这篇论文的主要研究问题是什么？" |
+| 总结归纳 (SUMM) | 3 | "请用三句话概括这篇论文的核心贡献。" |
+| 批判分析 (CRIT) | 3 | "这篇论文的局限性是什么？" |
+| 交叉引用 (CROSS) | 2 | "结合我做的笔记，这篇论文和之前阅读的论文有什么联系？" |
+
+### 10.6 评分与 SLA 指标
+
+- **相关性评分**: 0-5 分（基于回答长度、关键词覆盖、来源引用）
+- **响应时间 SLA**: ≤5s（目标 60%）/ ≤10s（目标 85%）/ ≤30s（目标 95%）
+- **综合评分**: 通过率(40%) + 相关性(40%) + 速度(20%)
+
+---
+
+## 11. OpenAPI 文档（Apifox / Postman 导入）
+
+已预生成 OpenAPI 3.1.0 规范文件，可直接导入 API 调试工具：
+
+```
+src/backend/openapi.json
+```
+
+**导入方式：**
+- **Apifox**: 新建项目 → 导入 → OpenAPI/Swagger → 选择该文件
+- **Postman**: File → Import → Upload Files → 选择该文件
+
+如需重新生成（例如修改路由后），在 `src/backend` 目录下执行：
+
+```bash
+python export_openapi.py
+```
+
+> 注意：WebSocket 端点 `/api/ws/chat` 不在 OpenAPI 规范中（Swagger 不支持描述 WebSocket），请参考 §10.4 的协议说明手动在 Apifox 中创建 WebSocket 调试。
 
 #

--- a/src/backend/tests/run_qa_scenario_tests.py
+++ b/src/backend/tests/run_qa_scenario_tests.py
@@ -1,0 +1,87 @@
+"""
+AI 问答场景化测试 — 统一运行入口
+
+运行所有场景化测试：
+  python tests/run_qa_scenario_tests.py
+
+选择性运行：
+  python tests/run_qa_scenario_tests.py --qa-only      # 仅运行标准问题集测试
+  python tests/run_qa_scenario_tests.py --ws-only       # 仅运行 WebSocket 测试
+  python tests/run_qa_scenario_tests.py --task-only     # 仅运行异步任务测试
+  python tests/run_qa_scenario_tests.py --all           # 运行全部（默认）
+"""
+
+import sys
+import subprocess
+import time
+
+
+def print_header(text: str):
+    print("\n" + "=" * 70)
+    print(f" {text}")
+    print("=" * 70)
+
+
+def run_test(module_name: str, description: str) -> bool:
+    print_header(f"运行: {description}")
+    start = time.time()
+    result = subprocess.run(
+        [sys.executable, f"tests/{module_name}"],
+        capture_output=False,
+        text=True,
+    )
+    elapsed = time.time() - start
+    success = result.returncode == 0
+    status = "✅ 通过" if success else "❌ 失败"
+    print(f"\n   {status} ({elapsed:.1f}s)")
+    return success
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="AI 问答场景化测试运行器")
+    parser.add_argument("--qa-only", action="store_true", help="仅运行标准问题集测试")
+    parser.add_argument("--ws-only", action="store_true", help="仅运行 WebSocket 测试")
+    parser.add_argument("--task-only", action="store_true", help="仅运行异步任务测试")
+    parser.add_argument("--all", action="store_true", default=True, help="运行全部测试")
+    args = parser.parse_args()
+
+    print_header("🧪 AI 问答助手场景化测试套件")
+
+    test_plan = [
+        ("test_qa_scenario.py", "标准问题集 × PDF 场景回答相关性"),
+        ("test_ws_conversation.py", "WebSocket 流式推送 + 多轮对话"),
+        ("test_task_async_push.py", "Celery 异步任务状态轮询"),
+    ]
+
+    if args.qa_only:
+        test_plan = test_plan[:1]
+    elif args.ws_only:
+        test_plan = test_plan[1:2]
+    elif args.task_only:
+        test_plan = test_plan[2:]
+
+    results = []
+    for module, desc in test_plan:
+        success = run_test(module, desc)
+        results.append((desc, success))
+
+    # 汇总
+    print_header("📊 测试汇总")
+    passed = sum(1 for _, s in results if s)
+    total = len(results)
+    print(f"\n   总计: {total}  通过: {passed}  失败: {total - passed}")
+    for desc, success in results:
+        status = "✅" if success else "❌"
+        print(f"   {status} {desc}")
+
+    if passed == total:
+        print("\n🎉 所有场景化测试通过！")
+    else:
+        print(f"\n⚠️  共 {total - passed} 项测试未通过，请检查上述报告。")
+
+    return 0 if passed == total else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/backend/tests/test_qa_scenario.py
+++ b/src/backend/tests/test_qa_scenario.py
@@ -1,0 +1,478 @@
+"""
+AI 问答助手场景化测试：标准问题集 + PDF 场景回答相关性 + 响应速度
+
+测试目标：
+  1. 构建覆盖多维度（事实提取、总结归纳、批判分析、交叉引用）的标准问题集
+  2. 验证 PDF 全文 + 笔记场景下 LLM 回答的相关性
+  3. 测量端到端响应时间，确保满足 SLA
+  4. 边界条件测试（空文本、超长文本、无笔记等）
+
+前置条件：
+  1. 后端运行在 http://localhost:8000
+  2. .env 中设置了 TEST_USER_ID（测试模式）或提供了有效登录凭据
+  3. 账号下至少有一篇 CONFIRMED 状态的论文（含 full_text 和 notes）
+
+运行方式：
+  pytest tests/test_qa_scenario.py -v --tb=short
+  或
+  python tests/test_qa_scenario.py
+"""
+
+import sys
+import json
+import time
+import urllib.request
+import urllib.error
+from dataclasses import dataclass, field
+from typing import Optional
+
+BASE_URL = "http://localhost:8000"
+TEST_USER_ID_ENV_VAR = "TEST_USER_ID"
+
+# ---------------------------------------------------------------------------
+# 标准问题集 —— 按认知维度分类
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TestQuestion:
+    """单个测试问题"""
+    id: str
+    question: str
+    category: str                # 问题类别
+    description: str             # 测试意图
+    min_answer_length: int = 50  # 期望回答最小字符数
+    requires_source: bool = True # 是否期望返回来源引用
+    expected_keywords: list = field(default_factory=list)  # 期望出现的关键词
+
+
+# 标准问题集
+STANDARD_QUESTIONS = [
+    # ── 事实提取类 ──
+    TestQuestion(
+        id="FACT-1",
+        question="这篇论文的主要研究问题是什么？",
+        category="fact_extraction",
+        description="验证能否准确提取研究问题",
+        min_answer_length=50,
+        expected_keywords=["研究", "问题"],
+    ),
+    TestQuestion(
+        id="FACT-2",
+        question="论文提出了什么创新方法？",
+        category="fact_extraction",
+        description="验证能否提取方法学创新点",
+        min_answer_length=50,
+        expected_keywords=["方法", "提出"],
+    ),
+    TestQuestion(
+        id="FACT-3",
+        question="论文的实验结果如何？主要性能指标是多少？",
+        category="fact_extraction",
+        description="验证能否提取实验结果数据",
+        min_answer_length=80,
+    ),
+    TestQuestion(
+        id="FACT-4",
+        question="论文的研究背景是什么？",
+        category="fact_extraction",
+        description="验证对研究背景的提取能力",
+        min_answer_length=50,
+    ),
+
+    # ── 总结归纳类 ──
+    TestQuestion(
+        id="SUMM-1",
+        question="请用三句话概括这篇论文的核心贡献。",
+        category="summarization",
+        description="验证摘要总结能力",
+        min_answer_length=100,
+    ),
+    TestQuestion(
+        id="SUMM-2",
+        question="这篇论文的应用场景有哪些？",
+        category="summarization",
+        description="验证能否归纳应用场景",
+        min_answer_length=60,
+    ),
+    TestQuestion(
+        id="SUMM-3",
+        question="论文中使用了哪些关键技术或算法？",
+        category="summarization",
+        description="验证技术细节归纳能力",
+        min_answer_length=60,
+    ),
+
+    # ── 批判分析类 ──
+    TestQuestion(
+        id="CRIT-1",
+        question="这篇论文的局限性是什么？",
+        category="critical_analysis",
+        description="验证能否识别论文局限性（若有讨论）",
+        min_answer_length=50,
+    ),
+    TestQuestion(
+        id="CRIT-2",
+        question="论文的实验设计是否合理？为什么？",
+        category="critical_analysis",
+        description="验证对实验设计的批判性思考",
+        min_answer_length=80,
+    ),
+    TestQuestion(
+        id="CRIT-3",
+        question="论文的结论是否有足够的数据支撑？",
+        category="critical_analysis",
+        description="验证对结论可靠性的判断",
+        min_answer_length=60,
+    ),
+
+    # ── 交叉引用类（依赖于笔记） ──
+    TestQuestion(
+        id="CROSS-1",
+        question="结合我做的笔记，这篇论文和之前阅读的论文有什么联系？",
+        category="cross_reference",
+        description="验证能否结合笔记进行关联分析",
+        min_answer_length=80,
+    ),
+    TestQuestion(
+        id="CROSS-2",
+        question="根据论文内容和我的笔记，这个领域下一步的研究方向可能是什么？",
+        category="cross_reference",
+        description="验证能否综合论文+笔记进行展望",
+        min_answer_length=80,
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# HTTP 工具
+# ---------------------------------------------------------------------------
+
+def _post(path: str, body: dict, token: str | None = None) -> dict:
+    data = json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body_bytes = e.read()
+        try:
+            return json.loads(body_bytes)
+        except json.JSONDecodeError:
+            return {"code": e.code, "msg": body_bytes.decode(), "data": None}
+
+
+def _get(path: str, token: str | None) -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+# ---------------------------------------------------------------------------
+# 评分辅助
+# ---------------------------------------------------------------------------
+
+def rate_relevance(answer: str, question: TestQuestion) -> dict:
+    """
+    对回答进行简单的相关性评分。
+    返回评分（0-5）和评分理由。
+    """
+    score = 3  # 默认中等
+    details = []
+
+    # 1. 长度检查
+    if len(answer) < question.min_answer_length:
+        score -= 1
+        details.append(f"回答过短 ({len(answer)} < {question.min_answer_length})")
+    elif len(answer) > 500:
+        score += 0.5
+        details.append("回答内容丰富")
+
+    # 2. 关键词匹配
+    if question.expected_keywords:
+        matched = sum(1 for kw in question.expected_keywords if kw in answer)
+        if matched >= len(question.expected_keywords):
+            score += 1
+            details.append("关键词覆盖完整")
+        elif matched > 0:
+            score += 0.5
+            details.append(f"部分关键词匹配 ({matched}/{len(question.expected_keywords)})")
+        else:
+            score -= 0.5
+            details.append("未匹配到期望关键词")
+
+    # 3. 检查是否有空洞回复
+    vague_patterns = ["无法回答", "没有足够信息", "暂无相关信息", "根据现有内容"]
+    if any(p in answer for p in vague_patterns):
+        score -= 1
+        details.append("回答倾向回避/空洞")
+
+    # 4. 引用检查
+    if "（论文正文）" in answer or "（笔记" in answer or "(full_text)" in answer.lower():
+        score += 0.5
+        details.append("包含来源引用")
+
+    score = max(0, min(5, score))
+    return {"score": round(score, 1), "details": "; ".join(details)}
+
+
+# ---------------------------------------------------------------------------
+# 测试结果收集
+# ---------------------------------------------------------------------------
+
+class TestResults:
+    def __init__(self):
+        self.questions: list[dict] = []
+        self.boundary_tests: list[dict] = []
+        self.timing_results: list[float] = []
+
+    def add_question_result(self, q: TestQuestion, answer: str, sources: list,
+                            elapsed: float, success: bool, error_msg: str = ""):
+        relevance = rate_relevance(answer, q) if success else {"score": 0, "details": error_msg}
+        self.questions.append({
+            "id": q.id,
+            "category": q.category,
+            "question": q.question,
+            "description": q.description,
+            "success": success,
+            "answer_preview": answer[:200] + ("..." if len(answer) > 200 else ""),
+            "answer_length": len(answer),
+            "sources_count": len(sources) if sources else 0,
+            "elapsed_seconds": round(elapsed, 2),
+            "relevance_score": relevance["score"],
+            "relevance_details": relevance["details"],
+            "error": error_msg,
+        })
+        self.timing_results.append(elapsed)
+
+    def add_boundary_result(self, name: str, status_code: int, response: dict, elapsed: float):
+        self.boundary_tests.append({
+            "name": name,
+            "status_code": status_code,
+            "response": response,
+            "elapsed_seconds": round(elapsed, 2),
+        })
+
+    def print_report(self):
+        """打印详细测试报告"""
+        print("\n" + "=" * 70)
+        print("📊 AI 问答场景化测试报告")
+        print("=" * 70)
+
+        # 总体统计
+        total = len(self.questions)
+        success = sum(1 for q in self.questions if q["success"])
+        avg_time = sum(self.timing_results) / len(self.timing_results) if self.timing_results else 0
+        avg_score = sum(q["relevance_score"] for q in self.questions) / total if total else 0
+
+        print(f"\n📈 总体统计:")
+        print(f"   问题总数: {total}")
+        print(f"   成功: {success} / 失败: {total - success}")
+        print(f"   平均响应时间: {avg_time:.2f}s")
+        print(f"   平均相关性评分: {avg_score:.2f} / 5.0")
+
+        # SLA 达标率
+        sla_targets = [
+            ("≤ 5秒", 5),
+            ("≤ 10秒", 10),
+            ("≤ 30秒", 30),
+        ]
+        print(f"\n⏱ 响应时间 SLA:")
+        for label, threshold in sla_targets:
+            count = sum(1 for t in self.timing_results if t <= threshold)
+            pct = count / len(self.timing_results) * 100
+            bar = "█" * int(pct / 5) + "░" * (20 - int(pct / 5))
+            print(f"   {label}: {bar} {pct:.0f}% ({count}/{len(self.timing_results)})")
+
+        # 按类别统计
+        print(f"\n📂 按类别统计:")
+        categories = {}
+        for q in self.questions:
+            cat = q["category"]
+            if cat not in categories:
+                categories[cat] = {"total": 0, "success": 0, "scores": [], "times": []}
+            categories[cat]["total"] += 1
+            if q["success"]:
+                categories[cat]["success"] += 1
+            categories[cat]["scores"].append(q["relevance_score"])
+            categories[cat]["times"].append(q["elapsed_seconds"])
+
+        cat_names = {
+            "fact_extraction": "事实提取",
+            "summarization": "总结归纳",
+            "critical_analysis": "批判分析",
+            "cross_reference": "交叉引用",
+        }
+        for cat, stats in sorted(categories.items()):
+            avg_s = sum(stats["scores"]) / len(stats["scores"]) if stats["scores"] else 0
+            avg_t = sum(stats["times"]) / len(stats["times"]) if stats["times"] else 0
+            name = cat_names.get(cat, cat)
+            print(f"   {name}: {stats['success']}/{stats['total']} 通过 | "
+                  f"平均评分 {avg_s:.1f} | 平均响应 {avg_t:.2f}s")
+
+        # 逐题详情
+        print(f"\n📋 逐题详情:")
+        for q in self.questions:
+            status = "✅" if q["success"] else "❌"
+            bar = "█" * int(q["relevance_score"] * 4) + "░" * (20 - int(q["relevance_score"] * 4))
+            print(f"\n   {status} [{q['id']}] {q['question'][:60]}")
+            print(f"      类别: {q['category']} | 时间: {q['elapsed_seconds']:.2f}s | "
+                  f"评分: {q['relevance_score']}/5.0")
+            print(f"      相关度: {bar}")
+            print(f"      回答预览: {q['answer_preview']}")
+            if q["error"]:
+                print(f"      错误: {q['error']}")
+
+        # 边界测试
+        if self.boundary_tests:
+            print(f"\n🧪 边界测试:")
+            for bt in self.boundary_tests:
+                status = "✅" if bt["status_code"] in (200, 400, 404, 422) else "❌"
+                print(f"   {status} {bt['name']}: {bt['status_code']} ({bt['elapsed_seconds']:.2f}s)")
+
+        # 综合评分
+        print(f"\n🏆 综合评分:")
+        final_score = (success / total * 40 if total else 0) + min(avg_score * 10, 40) + max(0, 20 - avg_time)
+        final_score = min(100, final_score)
+        grade = "A" if final_score >= 90 else "B" if final_score >= 75 else "C" if final_score >= 60 else "D"
+        print(f"   得分: {final_score:.1f}/100 (等级 {grade})")
+        print(f"   通过率: {success}/{total} + 相关性: {avg_score:.1f}/5 + 速度: {avg_time:.1f}s")
+        print("=" * 70)
+
+
+# ---------------------------------------------------------------------------
+# 主测试流程
+# ---------------------------------------------------------------------------
+
+def main():
+    print("=" * 70)
+    print("🧪 AI 问答助手场景化测试")
+    print("   标准问题集 × PDF 场景回答相关性 × 响应速度")
+    print("=" * 70)
+
+    results = TestResults()
+
+    # ── 步骤 1: 健康检查 ──
+    print("\n1️⃣  健康检查...")
+    try:
+        resp = _get("/health", None)
+        if resp.get("status") == "ok":
+            print("    ✅ 后端服务正常")
+        else:
+            print(f"    ❌ 后端状态异常: {resp}")
+            sys.exit(1)
+    except Exception as e:
+        print(f"    ❌ 后端服务未启动: {e}")
+        sys.exit(1)
+
+    # ── 步骤 2: 认证 ──
+    print("\n2️⃣  认证...")
+    token = None
+    try:
+        resp = _get("/api/papers/", None)
+        if resp.get("code") == 0:
+            print("    ✅ 测试模式已启用（无需 token）")
+            token = None
+        else:
+            print("    ⚠️  测试模式未启用，尝试登录...")
+            # 从环境变量或配置读取
+            import os
+            email = os.getenv("TEST_EMAIL", "test@example.com")
+            password = os.getenv("TEST_PASSWORD", "your_password")
+            resp = _post("/api/user/login", {"email": email, "password": password})
+            if resp.get("code") != 0:
+                print(f"    ❌ 登录失败: {resp.get('msg')}")
+                sys.exit(1)
+            token = resp["data"]["token"]
+            print(f"    ✅ 登录成功")
+    except Exception as e:
+        print(f"    ❌ 认证失败: {e}")
+        sys.exit(1)
+
+    # ── 步骤 3: 获取论文 ──
+    print("\n3️⃣  获取论文列表...")
+    resp = _get("/api/papers/", token)
+    papers = resp.get("data", [])
+    if not papers:
+        print("    ❌ 账号下无论文，请先上传并解析一篇论文")
+        sys.exit(1)
+
+    # 筛选 CONFIRMED 论文
+    confirmed = [p for p in papers if p.get("status") == "CONFIRMED"]
+    if not confirmed:
+        print("    ⚠️  无 CONFIRMED 论文，使用第一篇论文")
+        paper = papers[0]
+    else:
+        paper = confirmed[0]
+
+    paper_id = paper["id"]
+    print(f"    ✅ 使用论文: [{paper.get('status', '?')}] {paper['title'][:60]}...")
+
+    # ── 步骤 4: 执行标准问题集测试 ──
+    print(f"\n4️⃣  执行标准问题集测试 ({len(STANDARD_QUESTIONS)} 题)...")
+    for i, q in enumerate(STANDARD_QUESTIONS, 1):
+        print(f"\n    [{i}/{len(STANDARD_QUESTIONS)}] [{q.id}] ({q.category}) {q.question[:60]}...")
+        start = time.time()
+        resp = _post(f"/api/papers/{paper_id}/ask", {"question": q.question}, token)
+        elapsed = time.time() - start
+
+        code = resp.get("code")
+        if code == 0:
+            answer = resp.get("data", {}).get("answer", "")
+            sources = resp.get("data", {}).get("sources", [])
+            results.add_question_result(q, answer, sources, elapsed, success=True)
+            print(f"       ✅ {elapsed:.2f}s | 回答长度: {len(answer)} | 来源: {len(sources)}")
+        else:
+            results.add_question_result(q, "", [], elapsed, success=False,
+                                        error_msg=resp.get("msg", "未知错误"))
+            print(f"       ❌ ({resp.get('code')}): {resp.get('msg')}")
+
+    # ── 步骤 5: 边界测试 ──
+    print(f"\n5️⃣  边界测试...")
+
+    # 5a. 空问题
+    start = time.time()
+    resp = _post(f"/api/papers/{paper_id}/ask", {"question": ""}, token)
+    elapsed = time.time() - start
+    results.add_boundary_result("空问题", resp.get("code", 0), resp, elapsed)
+    print(f"    {'✅' if resp.get('code') in (0, 400, 422) else '❌'} 空问题: code={resp.get('code')} ({elapsed:.2f}s)")
+
+    # 5b. 不存在的论文
+    start = time.time()
+    resp = _post("/api/papers/nonexistent_id_12345/ask", {"question": "test"}, token)
+    elapsed = time.time() - start
+    results.add_boundary_result("不存在论文", resp.get("code", 0), resp, elapsed)
+    print(f"    {'✅' if resp.get('code') in (404, 401) else '❌'} 不存在论文: code={resp.get('code')} ({elapsed:.2f}s)")
+
+    # 5c. 超长问题（超过 2000 字）
+    long_question = "请回答" + "测试" * 1500
+    start = time.time()
+    resp = _post(f"/api/papers/{paper_id}/ask", {"question": long_question}, token)
+    elapsed = time.time() - start
+    results.add_boundary_result("超长问题", resp.get("code", 0), resp, elapsed)
+    print(f"    {'✅' if resp.get('code') in (0, 400, 422) else '❌'} 超长问题: code={resp.get('code')} ({elapsed:.2f}s)")
+
+    # 5d. 特殊字符问题
+    special_question = "!@#$%^&*()_+{}:\"<>?/.,';][=-`~"
+    start = time.time()
+    resp = _post(f"/api/papers/{paper_id}/ask", {"question": special_question}, token)
+    elapsed = time.time() - start
+    results.add_boundary_result("特殊字符", resp.get("code", 0), resp, elapsed)
+    print(f"    {'✅' if resp.get('code') == 0 else '❌'} 特殊字符: code={resp.get('code')} ({elapsed:.2f}s)")
+
+    # ── 步骤 6: 打印报告 ──
+    results.print_report()
+
+    # ── 返回测试结果 ──
+    success_rate = sum(1 for q in results.questions if q["success"]) / len(results.questions) if results.questions else 0
+    return success_rate >= 0.7  # 70% 通过率视为合格
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/src/backend/tests/test_task_async_push.py
+++ b/src/backend/tests/test_task_async_push.py
@@ -1,0 +1,244 @@
+"""
+Celery 异步任务推送测试 — 验证 PDF 解析流程的异步任务状态轮询。
+
+测试目标：
+  1. PDF 上传后返回有效的 task_id
+  2. 轮询 GET /api/tasks/{task_id} 能获取任务进度
+  3. 任务状态流转正确（PENDING → SUCCESS/FAILURE）
+  4. 边界情况：查询不存在的 task_id
+
+前置条件：
+  1. 后端运行在 http://localhost:8000
+  2. Celery Worker 已启动（见 readme.md）
+  3. Redis 服务运行中
+  4. .env 中设置了 TEST_USER_ID 或有效登录凭据
+
+运行方式：
+  pytest tests/test_task_async_push.py -v --tb=short
+  或
+  python tests/test_task_async_push.py
+"""
+
+import sys
+import json
+import time
+import urllib.request
+import urllib.error
+
+BASE_URL = "http://localhost:8000"
+
+# 任务状态轮询配置
+POLL_INTERVAL = 2    # 轮询间隔（秒）
+MAX_POLL_TIME = 120  # 最大等待时间（秒）
+
+
+def _post(path: str, body: dict, token: str | None = None) -> dict:
+    data = json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return json.loads(e.read())
+        except Exception:
+            return {"code": e.code, "msg": "HTTP error", "data": None}
+
+
+def _get(path: str, token: str | None) -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def _get_token() -> str | None:
+    """获取认证 token。"""
+    resp = _get("/api/papers/", None)
+    if resp.get("code") == 0:
+        return None  # 测试模式
+    import os
+    email = os.getenv("TEST_EMAIL", "test@example.com")
+    password = os.getenv("TEST_PASSWORD", "your_password")
+    resp = _post("/api/user/login", {"email": email, "password": password})
+    if resp.get("code") != 0:
+        print(f"❌ 登录失败: {resp.get('msg')}")
+        sys.exit(1)
+    return resp["data"]["token"]
+
+
+def poll_task(task_id: str, timeout: int = MAX_POLL_TIME) -> dict:
+    """
+    轮询任务状态，直到任务完成或超时。
+
+    Args:
+        task_id: Celery 任务 ID
+        timeout: 最大等待秒数
+
+    Returns:
+        任务结果字典，包含 status, result/error 等字段
+    """
+    start = time.time()
+    last_status = None
+
+    print(f"\n    开始轮询任务 {task_id[:8]}...")
+    while time.time() - start < timeout:
+        elapsed = time.time() - start
+        resp = _get(f"/api/tasks/{task_id}", None)
+
+        status = resp.get("status", "UNKNOWN")
+        if status != last_status:
+            print(f"    📡 [{elapsed:5.1f}s] 状态: {status}")
+            last_status = status
+
+        if status == "SUCCESS":
+            print(f"    ✅ 任务成功完成 (耗时 {elapsed:.1f}s)")
+            return resp
+        elif status == "FAILURE":
+            error = resp.get("error", "未知错误")
+            print(f"    ❌ 任务失败: {error}")
+            return resp
+        elif status == "REVOKED":
+            print(f"    ⚠️  任务被撤销")
+            return resp
+
+        time.sleep(POLL_INTERVAL)
+
+    print(f"    ⏰ 轮询超时 ({timeout}s)")
+    return {"status": "TIMEOUT", "task_id": task_id}
+
+
+def main():
+    print("=" * 70)
+    print("🧪 Celery 异步任务推送测试")
+    print("   任务状态轮询 × PDF 解析流程")
+    print("=" * 70)
+
+    results = {"passed": 0, "failed": 0, "tests": []}
+
+    # ── 1. 健康检查 ──
+    print("\n1️⃣  前置检查...")
+    try:
+        resp = _get("/health", None)
+        assert resp.get("status") == "ok"
+        print("    ✅ 后端服务正常")
+    except Exception as e:
+        print(f"    ❌ 后端服务异常: {e}")
+        sys.exit(1)
+
+    token = _get_token()
+    print(f"    ✅ 认证完成")
+
+    # ── 2. Ping 任务测试 ──
+    print("\n2️⃣  Ping 任务测试...")
+    try:
+        resp = _post("/api/tasks/ping", {}, token)
+        task_id = resp.get("task_id")
+        assert task_id, "未返回 task_id"
+        print(f"    ✅ Ping 任务提交成功: task_id={task_id[:8]}...")
+
+        # 轮询
+        result = poll_task(task_id, timeout=30)
+        assert result.get("status") == "SUCCESS", f"Ping 任务未成功: {result}"
+
+        results["tests"].append({
+            "name": "ping_task",
+            "success": True,
+            "detail": f"task_id={task_id[:8]}..., status={result['status']}",
+        })
+        results["passed"] += 1
+        print(f"    ✅ Ping 任务测试通过")
+    except Exception as e:
+        results["tests"].append({
+            "name": "ping_task",
+            "success": False,
+            "detail": str(e),
+        })
+        results["failed"] += 1
+        print(f"    ❌ Ping 任务测试失败: {e}")
+
+    # ── 3. 任务状态查询边界测试 ──
+    print("\n3️⃣  边界测试...")
+
+    # 3a. 不存在的 task_id
+    try:
+        resp = _get("/api/tasks/nonexistent-task-id-12345", None)
+        status = resp.get("status", "N/A")
+        # 不存在的任务应返回 PENDING 或错误
+        results["tests"].append({
+            "name": "nonexistent_task",
+            "success": True,
+            "detail": f"不存在任务查询: status={status}",
+        })
+        results["passed"] += 1
+        print(f"    ✅ 不存在任务查询: status={status}")
+    except Exception as e:
+        results["tests"].append({
+            "name": "nonexistent_task",
+            "success": False,
+            "detail": str(e),
+        })
+        results["failed"] += 1
+        print(f"    ❌ 不存在任务查询失败: {e}")
+
+    # 3b. 无效 task_id 格式
+    try:
+        resp = _get("/api/tasks/", None)
+        # 期望 404 或错误
+        results["tests"].append({
+            "name": "invalid_task_id",
+            "success": True,
+            "detail": f"无效 task_id 响应: code={resp.get('code', 'N/A')}",
+        })
+        results["passed"] += 1
+        print(f"    ✅ 无效 task_id 格式: 正确处理")
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            results["tests"].append({
+                "name": "invalid_task_id",
+                "success": True,
+                "detail": f"返回 404 正确",
+            })
+            results["passed"] += 1
+            print(f"    ✅ 无效 task_id: 返回 404")
+        else:
+            results["tests"].append({
+                "name": "invalid_task_id",
+                "success": False,
+                "detail": f"HTTP {e.code}",
+            })
+            results["failed"] += 1
+            print(f"    ❌ 无效 task_id: 返回 {e.code}")
+
+    # ── 4. 打印报告 ──
+    print("\n" + "=" * 70)
+    print("📊 异步任务推送测试报告")
+    print("=" * 70)
+
+    total = results["passed"] + results["failed"]
+    print(f"\n📈 统计:")
+    print(f"   测试总数: {total}")
+    print(f"   通过: {results['passed']}")
+    print(f"   失败: {results['failed']}")
+    print(f"   通过率: {results['passed']/total*100:.1f}%" if total else "   无测试")
+
+    print(f"\n📋 详情:")
+    for t in results["tests"]:
+        status = "✅" if t["success"] else "❌"
+        print(f"   {status} {t['name']}: {t['detail']}")
+
+    grade = "A" if results["failed"] == 0 else "B" if results["failed"] <= total * 0.2 else "C"
+    print(f"\n🏆 综合评定: {grade}")
+    print("=" * 70)
+
+    return results["failed"] == 0
+
+
+if __name__ == "__main__":
+    success = main()
+    sys.exit(0 if success else 1)

--- a/src/backend/tests/test_ws_conversation.py
+++ b/src/backend/tests/test_ws_conversation.py
@@ -1,0 +1,554 @@
+"""
+WebSocket 异步推送 + 多轮对话上下文连贯性测试。
+
+测试目标：
+  1. WebSocket 连接建立与认证
+  2. 流式 token 推送（逐个 token 到达）
+  3. 多轮对话上下文连贯性（追问时能否引用前文）
+  4. Celery 任务状态异步推送（模拟）
+  5. 连接断开与重连
+  6. 边界情况（空消息、超长消息、并发对话）
+
+前置条件：
+  1. 后端运行在 http://localhost:8000
+  2. .env 中设置了 TEST_USER_ID（测试模式）或提供了有效登录凭据
+  3. 账号下至少有一篇 CONFIRMED 状态的论文（含 full_text）
+
+运行方式：
+  pytest tests/test_ws_conversation.py -v --tb=short
+  或
+  python tests/test_ws_conversation.py
+"""
+
+import sys
+import json
+import time
+import asyncio
+import urllib.request
+import urllib.error
+from typing import Optional
+
+BASE_URL = "http://localhost:8000"
+WS_BASE_URL = "ws://localhost:8000"
+
+# 尝试导入 websocket 库
+try:
+    import websockets
+except ImportError:
+    print("需要安装 websockets 库：pip install websockets")
+    print("正在尝试自动安装...")
+    import subprocess
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "websockets"])
+    import websockets
+
+
+# ---------------------------------------------------------------------------
+# HTTP 工具（获取 token 和论文信息）
+# ---------------------------------------------------------------------------
+
+def _post(path: str, body: dict, token: str | None = None) -> dict:
+    data = json.dumps(body).encode()
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        try:
+            return json.loads(e.read())
+        except Exception:
+            return {"code": e.code, "msg": "HTTP error", "data": None}
+
+
+def _get(path: str, token: str | None) -> dict:
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(f"{BASE_URL}{path}", headers=headers)
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def _get_token_and_paper() -> tuple:
+    """获取认证 token 和第一篇 CONFIRMED 论文的 ID。"""
+    # 健康检查
+    try:
+        resp = _get("/health", None)
+        assert resp.get("status") == "ok", "后端服务异常"
+    except Exception as e:
+        print(f"❌ 后端服务未启动: {e}")
+        sys.exit(1)
+
+    # 认证
+    token = None
+    resp = _get("/api/papers/", None)
+    if resp.get("code") == 0:
+        token = None  # 测试模式
+    else:
+        import os
+        email = os.getenv("TEST_EMAIL", "test@example.com")
+        password = os.getenv("TEST_PASSWORD", "your_password")
+        resp = _post("/api/user/login", {"email": email, "password": password})
+        if resp.get("code") != 0:
+            print(f"❌ 登录失败: {resp.get('msg')}")
+            sys.exit(1)
+        token = resp["data"]["token"]
+
+    # 获取论文
+    resp = _get("/api/papers/", token)
+    papers = resp.get("data", [])
+    confirmed = [p for p in papers if p.get("status") == "CONFIRMED"]
+    if not confirmed:
+        print("❌ 无 CONFIRMED 论文")
+        sys.exit(1)
+
+    return token, confirmed[0]["id"]
+
+
+# ---------------------------------------------------------------------------
+# 测试用例
+# ---------------------------------------------------------------------------
+
+class WSTestSuite:
+    """WebSocket + 多轮对话测试套件"""
+
+    def __init__(self, token: str, paper_id: str):
+        self.token = token
+        self.paper_id = paper_id
+        self.results: list[dict] = []
+        self.jwt_token = self._extract_jwt(token)
+
+    def _extract_jwt(self, token: str | None) -> str:
+        """获取真正的 JWT token 用于 WS 认证。"""
+        if token is None:
+            # 测试模式下需要先登录获取 token
+            import os
+            email = os.getenv("TEST_EMAIL", "test@example.com")
+            password = os.getenv("TEST_PASSWORD", "your_password")
+            resp = _post("/api/user/login", {"email": email, "password": password})
+            if resp.get("code") == 0:
+                return resp["data"]["token"]
+            return ""
+        return token
+
+    async def test_connection(self) -> bool:
+        """测试 1: WebSocket 连接与认证"""
+        print("\n  📡 测试 1: WebSocket 连接与认证")
+        async with websockets.connect(
+            f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+            ping_interval=20,
+            ping_timeout=10,
+        ) as ws:
+            # 发送一个简单问题验证连接
+            await ws.send(json.dumps({
+                "type": "question",
+                "content": "你好，请做一个简短的自我介绍。"
+            }))
+            responses = []
+            async for msg in ws:
+                data = json.loads(msg)
+                responses.append(data)
+                if data["type"] in ("done", "error"):
+                    break
+
+            success = any(r["type"] == "done" for r in responses)
+            has_tokens = any(r["type"] == "token" for r in responses)
+            self.results.append({
+                "test": "connection_and_auth",
+                "success": success,
+                "detail": f"收到 {len(responses)} 条消息, token推送: {has_tokens}",
+            })
+            print(f"    {'✅' if success else '❌'} 连接认证: {'通过' if success else '失败'}")
+            print(f"    收到 {len(responses)} 条消息, 含 token 推送: {has_tokens}")
+            return success
+
+    async def test_streaming_push(self) -> bool:
+        """测试 2: 流式 token 推送"""
+        print("\n  📡 测试 2: 流式 token 推送")
+        async with websockets.connect(
+            f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+        ) as ws:
+            await ws.send(json.dumps({
+                "type": "question",
+                "content": "请简要总结这篇论文的核心贡献。"
+            }))
+
+            tokens = []
+            final_answer = ""
+            start_time = time.time()
+            first_token_time = None
+
+            async for msg in ws:
+                data = json.loads(msg)
+                if data["type"] == "token":
+                    if first_token_time is None:
+                        first_token_time = time.time()
+                    tokens.append(data["content"])
+                elif data["type"] == "done":
+                    final_answer = data["content"]
+                    break
+                elif data["type"] == "error":
+                    self.results.append({
+                        "test": "streaming_push",
+                        "success": False,
+                        "detail": f"服务端错误: {data['content']}",
+                    })
+                    return False
+
+            total_time = time.time() - start_time
+            ttf = (first_token_time - start_time) if first_token_time else total_time
+
+            # 评估流式效果
+            has_tokens = len(tokens) > 0
+            is_streaming = len(tokens) > 3  # 超过 3 个 token 视为真正流式
+            has_final = len(final_answer) > 50
+
+            success = has_tokens and has_final
+            self.results.append({
+                "test": "streaming_push",
+                "success": success,
+                "detail": (f"tokens: {len(tokens)}, 首token延迟: {ttf:.2f}s, "
+                          f"总耗时: {total_time:.2f}s, 回答长度: {len(final_answer)}"),
+            })
+            print(f"    {'✅' if success else '❌'} 流式推送: {'通过' if success else '失败'}")
+            print(f"    token 数: {len(tokens)}, 首 token 延迟: {ttf:.2f}s")
+            print(f"    总耗时: {total_time:.2f}s, 回答长度: {len(final_answer)}")
+            print(f"    真正流式: {'是' if is_streaming else '否（可能为一次性返回）'}")
+            return success
+
+    async def test_multi_turn_context(self) -> bool:
+        """测试 3: 多轮对话上下文连贯性"""
+        print("\n  📡 测试 3: 多轮对话上下文连贯性")
+
+        questions = [
+            "这篇论文的主要研究问题是什么？",
+            "他们用了什么方法来解决这个问题？",       # 期望能引用"研究问题"
+            "这个方法相比于传统方法有什么优势？",       # 期望能引用"方法"
+            "根据之前讨论的内容，总结一下这篇论文的贡献。",  # 期望综合前文
+        ]
+
+        async with websockets.connect(
+            f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+        ) as ws:
+            context_awareness = []
+
+            for i, question in enumerate(questions):
+                print(f"\n    第 {i+1} 轮: {question[:50]}...")
+
+                # 先清除历史再提问，模拟全新对话
+                if i > 0:
+                    # 不清除历史，保持上下文
+                    pass
+
+                await ws.send(json.dumps({
+                    "type": "question",
+                    "content": question,
+                }))
+
+                answer = ""
+                async for msg in ws:
+                    data = json.loads(msg)
+                    if data["type"] == "token":
+                        answer += data["content"]
+                    elif data["type"] == "done":
+                        answer = data["content"]
+                        break
+                    elif data["type"] == "error":
+                        print(f"      ❌ 错误: {data['content']}")
+                        break
+
+                # 评估回答质量
+                has_content = len(answer) > 30
+                print(f"      回答长度: {len(answer)}")
+
+                # 上下文连贯性检测：第2轮问题应提及"方法"，第4轮应综合前文
+                if i == 3:
+                    # 综合轮次，期望引用前文
+                    references_previous = any(
+                        kw in answer for kw in ["研究问题", "方法", "优势", "前面", "如上", "之前"]
+                    )
+                    context_awareness.append(references_previous)
+                    print(f"      引用前文: {'是' if references_previous else '否'}")
+
+            success = all(ca for ca in context_awareness) if context_awareness else True
+            self.results.append({
+                "test": "multi_turn_context",
+                "success": success,
+                "detail": f"{len(questions)} 轮对话, 上下文引用: {context_awareness}",
+            })
+            print(f"    {'✅' if success else '❌'} 多轮对话: {'通过' if success else '失败'}")
+            return success
+
+    async def test_concurrent_sessions(self) -> bool:
+        """测试 4: 并发 WebSocket 连接"""
+        print("\n  📡 测试 4: 并发 WebSocket 连接")
+        n_concurrent = 3
+
+        async def single_session(session_id: int) -> dict:
+            try:
+                async with websockets.connect(
+                    f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+                    ping_interval=20,
+                    ping_timeout=10,
+                ) as ws:
+                    await ws.send(json.dumps({
+                        "type": "question",
+                        "content": f"这是会话 {session_id} 的测试问题。"
+                    }))
+                    responses = []
+                    async for msg in ws:
+                        data = json.loads(msg)
+                        responses.append(data["type"])
+                        if data["type"] in ("done", "error"):
+                            break
+                    return {"id": session_id, "success": "done" in responses, "count": len(responses)}
+            except Exception as e:
+                return {"id": session_id, "success": False, "error": str(e)}
+
+        tasks = [single_session(i) for i in range(n_concurrent)]
+        session_results = await asyncio.gather(*tasks)
+
+        all_success = all(r["success"] for r in session_results)
+        self.results.append({
+            "test": "concurrent_sessions",
+            "success": all_success,
+            "detail": f"{n_concurrent} 个并发会话, 全部成功: {all_success}",
+        })
+        for r in session_results:
+            status = "✅" if r["success"] else "❌"
+            print(f"    {status} 会话 {r['id']}: {'成功' if r['success'] else '失败'}")
+        return all_success
+
+    async def test_clear_context(self) -> bool:
+        """测试 5: 清除上下文"""
+        print("\n  📡 测试 5: 清除对话上下文")
+        async with websockets.connect(
+            f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+        ) as ws:
+            # 先发一个问题建立上下文
+            await ws.send(json.dumps({"type": "question", "content": "这是第一个问题。"}))
+            async for msg in ws:
+                data = json.loads(msg)
+                if data["type"] in ("done", "error"):
+                    break
+
+            # 清除上下文
+            await ws.send(json.dumps({"type": "clear"}))
+            clear_resp = await asyncio.wait_for(ws.recv(), timeout=5)
+            clear_data = json.loads(clear_resp)
+            success = clear_data.get("type") == "status" and clear_data.get("content") == "context_cleared"
+
+            self.results.append({
+                "test": "clear_context",
+                "success": success,
+                "detail": f"清除响应: {clear_data.get('type')} / {clear_data.get('content')}",
+            })
+            print(f"    {'✅' if success else '❌'} 清除上下文: {'通过' if success else '失败'}")
+            return success
+
+    async def test_edge_cases(self) -> bool:
+        """测试 6: 边界情况"""
+        print("\n  📡 测试 6: 边界情况测试")
+        edge_results = []
+
+        async with websockets.connect(
+            f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+        ) as ws:
+            # 6a. 空消息
+            await ws.send(json.dumps({"type": "question", "content": ""}))
+            resp = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            empty_ok = resp.get("type") == "error"
+            edge_results.append(("空消息", empty_ok))
+            print(f"    {'✅' if empty_ok else '❌'} 空消息: {'正确拒绝' if empty_ok else '未拒绝'}")
+
+            # 6b. 无效 JSON
+            await ws.send("这不是 JSON")
+            resp = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            invalid_ok = resp.get("type") == "error"
+            edge_results.append(("无效JSON", invalid_ok))
+            print(f"    {'✅' if invalid_ok else '❌'} 无效JSON: {'正确拒绝' if invalid_ok else '未拒绝'}")
+
+            # 6c. 未知消息类型
+            await ws.send(json.dumps({"type": "unknown_type", "content": "test"}))
+            resp = json.loads(await asyncio.wait_for(ws.recv(), timeout=10))
+            unknown_ok = resp.get("type") == "error"
+            edge_results.append(("未知类型", unknown_ok))
+            print(f"    {'✅' if unknown_ok else '❌'} 未知类型: {'正确拒绝' if unknown_ok else '未拒绝'}")
+
+        all_pass = all(r for _, r in edge_results)
+        self.results.append({
+            "test": "edge_cases",
+            "success": all_pass,
+            "detail": f"空消息={'通过' if edge_results[0][1] else '失败'}, "
+                      f"无效JSON={'通过' if edge_results[1][1] else '失败'}, "
+                      f"未知类型={'通过' if edge_results[2][1] else '失败'}",
+        })
+        return all_pass
+
+    async def test_reconnection(self) -> bool:
+        """测试 7: 断线重连"""
+        print("\n  📡 测试 7: 断线重连")
+        try:
+            # 第一次连接并立即断开
+            ws1 = await websockets.connect(
+                f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+            )
+            await ws1.close()
+
+            # 等待短暂时间后重连
+            await asyncio.sleep(0.5)
+            async with websockets.connect(
+                f"{WS_BASE_URL}/api/ws/chat?token={self.jwt_token}&paper_id={self.paper_id}",
+            ) as ws2:
+                await ws2.send(json.dumps({
+                    "type": "question",
+                    "content": "重连后的测试问题。"
+                }))
+                async for msg in ws2:
+                    data = json.loads(msg)
+                    if data["type"] in ("done", "error"):
+                        break
+
+            success = True
+            self.results.append({
+                "test": "reconnection",
+                "success": True,
+                "detail": "断线重连成功",
+            })
+            print(f"    ✅ 断线重连: 通过")
+            return True
+        except Exception as e:
+            self.results.append({
+                "test": "reconnection",
+                "success": False,
+                "detail": f"重连失败: {e}",
+            })
+            print(f"    ❌ 断线重连: 失败 - {e}")
+            return False
+
+    async def run_all(self):
+        """运行所有测试"""
+        print("\n" + "=" * 70)
+        print("🧪 WebSocket 异步推送 + 多轮对话测试")
+        print("=" * 70)
+
+        tests = [
+            ("连接与认证", self.test_connection()),
+            ("流式 token 推送", self.test_streaming_push()),
+            ("多轮对话上下文", self.test_multi_turn_context()),
+            ("并发会话", self.test_concurrent_sessions()),
+            ("清除上下文", self.test_clear_context()),
+            ("边界情况", self.test_edge_cases()),
+            ("断线重连", self.test_reconnection()),
+        ]
+
+        for name, coro in tests:
+            try:
+                await asyncio.wait_for(coro, timeout=60)
+            except asyncio.TimeoutError:
+                self.results.append({
+                    "test": name,
+                    "success": False,
+                    "detail": "超时 (60s)",
+                })
+                print(f"    ❌ {name}: 超时")
+
+        self.print_report()
+
+    def print_report(self):
+        """打印测试报告"""
+        print("\n" + "=" * 70)
+        print("📊 WebSocket + 多轮对话测试报告")
+        print("=" * 70)
+
+        total = len(self.results)
+        passed = sum(1 for r in self.results if r["success"])
+
+        print(f"\n📈 总体统计:")
+        print(f"   测试项总数: {total}")
+        print(f"   通过: {passed} / 失败: {total - passed}")
+        print(f"   通过率: {passed/total*100:.1f}%" if total else "   无测试结果")
+
+        print(f"\n📋 测试详情:")
+        for r in self.results:
+            status = "✅" if r["success"] else "❌"
+            print(f"\n   {status} {r['test']}")
+            print(f"      详情: {r['detail']}")
+
+        grade = "A" if passed == total else "B" if passed >= total * 0.8 else "C"
+        print(f"\n🏆 综合评定: {grade}")
+        print("=" * 70)
+
+        return passed == total
+
+
+# ---------------------------------------------------------------------------
+# pytest 入口
+# ---------------------------------------------------------------------------
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ws_connection():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_connection()
+
+
+@pytest.mark.asyncio
+async def test_ws_streaming():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_streaming_push()
+
+
+@pytest.mark.asyncio
+async def test_ws_multi_turn():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_multi_turn_context()
+
+
+@pytest.mark.asyncio
+async def test_ws_concurrent():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_concurrent_sessions()
+
+
+@pytest.mark.asyncio
+async def test_ws_clear_context():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_clear_context()
+
+
+@pytest.mark.asyncio
+async def test_ws_edge_cases():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_edge_cases()
+
+
+@pytest.mark.asyncio
+async def test_ws_reconnection():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    assert await suite.test_reconnection()
+
+
+# ---------------------------------------------------------------------------
+# 直接运行入口
+# ---------------------------------------------------------------------------
+
+async def main():
+    token, paper_id = _get_token_and_paper()
+    suite = WSTestSuite(token, paper_id)
+    await suite.run_all()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### 概述

为 Scider 系统添加 AI 问答场景化测试套件和 WebSocket 实时流式聊天功能，覆盖标准问题集回答相关性、响应速度 SLA、多轮对话上下文连贯性及异步任务推送可靠性。

---

### 新增文件

| 文件 | 说明 |
|------|------|
| test_qa_scenario.py | **标准问题集测试** — 13 道覆盖 4 个认知维度（事实提取、总结归纳、批判分析、交叉引用）的问题，含自动相关性评分 (0-5) 和响应时间 SLA 统计 |
| test_ws_conversation.py | **WebSocket 流式 + 多轮对话测试** — 7 项测试（连接认证、流式 token 推送、多轮上下文连贯性、并发会话、清除上下文、边界情况、断线重连） |
| test_task_async_push.py | **Celery 异步任务推送测试** — Ping 任务提交流程、状态轮询（PENDING → SUCCESS/FAILURE）、边界情况（不存在/无效 task_id） |
| run_qa_scenario_tests.py | **统一测试运行入口** — 支持 `--qa-only` / `--ws-only` / `--task-only` / `--all` 选择性运行 |
| chat_ws.py | **WebSocket 流式聊天端点** — 基于 FastAPI WebSocket，支持逐 token 流式推送、多轮对话历史管理（最多 20 轮）、JWT 查询参数认证、连接管理器支持多用户多会话 |
| scenario-test-plan.md | **测试方案文档** — 完整测试计划、评分标准、SLA 指标、WebSocket 协议说明、运行指南 |

### 修改文件

| 文件 | 说明 |
|------|------|
| main.py | 注册 `chat_ws_router` 到 `/api` 前缀 |
| readme.md | 新增 §10「AI 问答场景化测试」章节（含前置条件、运行命令、WebSocket 协议、评分标准）和 §11「OpenAPI 文档导入」说明 |
| openapi.json | 重新导出，包含全部 47 个 HTTP 端点 + 28 个 schemas（可通过 `python export_openapi.py` 重新生成） |

### 关键设计决策

1. **无额外依赖** — 测试脚本运行时自动安装 `websockets` 库，无需手动配置
2. **双重测试模式** — 支持 `.env` 中 `TEST_USER_ID` 测试模式（免登录）和常规 JWT 登录模式
3. **WebSocket 认证** — JWT token 通过查询参数 `?token=` 传递，不在 WS 握手 Header 中（兼容浏览器 WebSocket API）
4. **测试报告自动化** — 运行后自动生成结构化报告，包含逐题评分、SLA 达标率、综合等级 (A/B/C/D)

### WebSocket 协议摘要

```
连接: ws://localhost:8000/api/ws/chat?token=<JWT>&paper_id=<PAPER_ID>

客户端 → 服务端:  {"type":"question","content":"..."} / {"type":"clear"}
服务端 → 客户端:  {"type":"token","content":"...","index":N} (流式)
                  {"type":"done","content":"...","sources":[...]} (完成)
                  {"type":"error","content":"..."} (错误)
```

### 测试运行

```bash
cd src/backend

# 前置条件：docker 启动 MySQL+Redis → alembic upgrade head → 启动 uvicorn → 启动 celery worker

# 统一运行
python tests/run_qa_scenario_tests.py
```