### PR TITLE
[fix]: backend cicd

### DIFF
--- a/.github/workflows/backend-cicd.yml
+++ b/.github/workflows/backend-cicd.yml
@@ -60,11 +60,13 @@ jobs:
           pip install -r requirements.txt
 
       - name: Run unit tests
-        run: pytest tests/ -v --timeout=60
+        run: pytest tests/ -v
         env:
           DATABASE_URL: mysql+asyncmy://root:218218wcj@127.0.0.1:3306/db?charset=utf8mb4
           REDIS_BROKER_URL: redis://127.0.0.1:6379/0
           REDIS_RESULT_BACKEND: redis://127.0.0.1:6379/1
+          JWT_SECRET: ci-test-jwt-secret-key-for-pipeline-2025
+          LLM_PROVIDER: deepseek
 
   # ──────────────────────────────────────────────
   # Build & Push Docker Images

--- a/src/backend/pytest.ini
+++ b/src/backend/pytest.ini
@@ -2,3 +2,5 @@
 pythonpath = .
 asyncio_mode = auto
 testpaths = tests
+timeout = 60
+timeout_method = thread

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -24,3 +24,4 @@ pytest>=8.0
 pytest-asyncio>=0.24
 pytest-timeout>=2.3
 bleach>=5.0
+websockets>=12.0

--- a/src/backend/tests/test_deployment.py
+++ b/src/backend/tests/test_deployment.py
@@ -116,7 +116,8 @@ def get_db_migration_version() -> str:
         迁移版本号
     """
     try:
-        result = run_command(["alembic", "current"], check=False)
+        # alembic.ini 位于 db/alembic.ini，需显式指定路径
+        result = run_command(["alembic", "-c", "db/alembic.ini", "current"], check=False)
         output = result.stdout.strip()
         # 从输出中提取版本号（格式：<revision> (head)）
         if output:
@@ -195,8 +196,8 @@ def test_database_migration():
     version_before = get_db_migration_version()
     print(f"  当前版本: {version_before}")
 
-    # 执行迁移（模拟：alembic upgrade head）
-    result = run_command(["alembic", "upgrade", "head"], timeout=60, check=False)
+    # 执行迁移（模拟：alembic upgrade head；alembic.ini 位于 db/ 下）
+    result = run_command(["alembic", "-c", "db/alembic.ini", "upgrade", "head"], timeout=60, check=False)
 
     if result.returncode != 0:
         pytest.fail(f"数据库迁移失败: {result.stderr}")


### PR DESCRIPTION
### 修复概览（4 个文件改动）

| # | 问题 | 修改文件 | 改动内容 |
|---|------|---------|---------|
| 1 | **CI 缺少环境变量** | backend-cicd.yml | 在 `Run unit tests` 步骤的 `env` 中添加了 `JWT_SECRET` 和 `LLM_PROVIDER` |
| 2 | **alembic 路径错误** | test_deployment.py | 两处 `alembic` 命令都加上了 `-c db/alembic.ini` 显式指定配置文件路径 |
| 3 | **websockets 未预装** | requirements.txt | 在测试依赖区添加 `websockets>=12.0` |
| 4 | **pytest-timeout 与 asyncio 冲突** | pytest.ini | 把 `--timeout=60` 从 CI 命令行移到 pytest.ini，并设置 `timeout_method = thread`（线程模式替代 SIGALRM，兼容 asyncio）；CI 命令中去掉 `--timeout=60` |

### 关键设计说明

- **`timeout_method = thread`**：这是最关键的修复。`pytest-timeout` 默认用 `SIGALRM` 信号实现超时，但这会中断 Python 的事件循环，导致所有 `@pytest.mark.asyncio` 测试损坏。线程模式不会干扰事件循环，是 asyncio 测试的正确选择。
- **`alembic -c db/alembic.ini`**：明确指定配置文件路径，避免依赖当前工作目录。
- **CI 中的 `JWT_SECRET`**：使用了一个仅用于 CI 管道的固定值，不影响生产环境。